### PR TITLE
fix: Apps not launching from wofi

### DIFF
--- a/hypr/conf/keybinds.conf
+++ b/hypr/conf/keybinds.conf
@@ -12,7 +12,7 @@ bind = $mainMod, E, exec, nautilus
 bind = $mainMod, C, exec, hyprpicker -a
 bind = $mainMod ,period, exec, wofimoji
 bind = $mainMod, return, exec, LIBGL_ALWAYS_SOFTWARE=1 kitty
-bind = $mainMod, space, exec, wofi --show drun --style ~/.config/wofi/themes/gruvbox.css
+bind = $mainMod, space, exec, ~/.config/hypr/scripts/launch_wofi.sh
 
 # Clipboard Manager (Cliphist + Wofi)
 bind = $mainMod, V, exec, cliphist list | wofi -dmenu -p "󰆒 Clipboard" --style ~/.config/wofi/themes/gruvbox.css | cliphist decode | wl-copy && wtype -M ctrl shift -P v -m ctrl

--- a/hypr/scripts/launch_wofi.sh
+++ b/hypr/scripts/launch_wofi.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+wofi --show drun --style ~/.config/wofi/themes/gruvbox.css | xargs hyprctl dispatch exec


### PR DESCRIPTION
This commit fixes an issue where applications would not launch when selected from wofi.

The issue was caused by wofi not correctly launching the application in the background. This was resolved by wrapping the wofi command in a shell script that pipes the selected application to `hyprctl dispatch exec`.