### PR TITLE
fix: Apps not launching from wofi

### DIFF
--- a/hypr/scripts/launch_wofi.sh
+++ b/hypr/scripts/launch_wofi.sh
@@ -1,2 +1,5 @@
 #!/bin/bash
-wofi --show drun --style ~/.config/wofi/themes/gruvbox.css | xargs hyprctl dispatch exec
+chosen=$(ls /usr/share/applications/*.desktop | sed 's/\.desktop//g' | sed 's/.*\///g' | wofi --show dmenu --style ~/.config/wofi/themes/gruvbox.css)
+if [ -n "$chosen" ]; then
+  gtk-launch "$chosen"
+fi


### PR DESCRIPTION
This commit fixes an issue where applications would not launch when selected from wofi.

The previous fix was not working because `wofi --show drun` was not outputting the command to be executed. This was resolved by using `wofi --dmenu` and parsing the `.desktop` files manually. The script now uses `gtk-launch` to start the applications, which is a more reliable method.