### PR TITLE
This change adds a command to the `startup.conf` to log all environme…

### DIFF
--- a/hypr/conf/startup.conf
+++ b/hypr/conf/startup.conf
@@ -2,6 +2,7 @@
 #----------------------------------------
 # Startup Programs & Commands
 #----------------------------------------
+exec-once = env > ~/hyprland-env.log
 exec-once = uwsm app -t service -- /usr/libexec/polkit-gnome-authentication-agent-1
 exec-once = uwsm app -t service -- waybar -c ~/.config/waybar/config.jsonc -s ~/.config/waybar/themes/gruv.css
 exec-once = uwsm app -t service -- wl-paste --type text --watch cliphist store


### PR DESCRIPTION
…nt variables to a file. This will help diagnose the issue with Wayland applications not launching correctly.