### PR TITLE
fix(hyprland): correctly finalize uwsm

### DIFF
--- a/hypr/conf/startup.conf
+++ b/hypr/conf/startup.conf
@@ -2,7 +2,6 @@
 #----------------------------------------
 # Startup Programs & Commands
 #----------------------------------------
-exec-once = env > ~/hyprland-env.log
 exec-once = uwsm app -t service -- /usr/libexec/polkit-gnome-authentication-agent-1
 exec-once = uwsm app -t service -- waybar -c ~/.config/waybar/config.jsonc -s ~/.config/waybar/themes/gruv.css
 exec-once = uwsm app -t service -- wl-paste --type text --watch cliphist store

--- a/hypr/hyprland.conf
+++ b/hypr/hyprland.conf
@@ -12,3 +12,5 @@ source = ~/.config/hypr/conf/settings.conf
 source = ~/.config/hypr/conf/keybinds.conf
 source = ~/.config/hypr/conf/startup.conf
 source = ~/.config/hypr/conf/windowrules.conf
+
+exec-once = uwsm finalize


### PR DESCRIPTION
This change ensures that `uwsm finalize` is executed correctly by adding it to the `hyprland.conf` file. This should resolve the issue with Wayland applications not being able to connect to the compositor.