### PR TITLE
fix: Correct wallpaper script and keybinding

### DIFF
--- a/hypr/custom/keybinds.conf
+++ b/hypr/custom/keybinds.conf
@@ -12,4 +12,4 @@ bind = Ctrl+Super+Alt, Slash, exec, xdg-open ~/.config/hypr/custom/keybinds.conf
 ##! Apps
 bind = Super, Space, exec, fuzzel
 bind = Super, V, exec, cliphist list | fuzzel -d | cliphist decode | wl-copy
-bind = Super, W, exec, ~/.config/hypr/custom/scripts/set-wallpaper.sh
+bind = Super+Alt, W, exec, ~/.config/hypr/custom/scripts/set-wallpaper.sh

--- a/hypr/custom/scripts/set-wallpaper.sh
+++ b/hypr/custom/scripts/set-wallpaper.sh
@@ -1,11 +1,21 @@
 #!/bin/bash
 
+# Check if zenity is installed
+if ! command -v zenity &> /dev/null; then
+    echo "zenity not found, please install it to use this script."
+    exit 1
+fi
+
 # Get the first monitor name
 monitor=$(hyprctl monitors | awk '/Monitor/ {print $2}')
 
-# Find a random wallpaper
-wallpaper_dir="$HOME/.config/wallpapers"
-wallpaper=$(find "$wallpaper_dir" -type f | shuf -n 1)
+# Open file picker to select a wallpaper
+wallpaper=$(zenity --file-selection --title="Select a wallpaper" --filename="$HOME/Pictures/wallpapers/")
+
+# Exit if no wallpaper is selected
+if [ -z "$wallpaper" ]; then
+    exit 0
+fi
 
 # Set the wallpaper with hyprpaper
 hyprctl hyprpaper unload all


### PR DESCRIPTION
This commit addresses the issues raised in the previous feedback.

- The keybinding for the set-wallpaper.sh script has been changed to Super+Alt+W to avoid conflicts with existing keybindings.
- The set-wallpaper.sh script has been updated to use zenity to provide a GUI file picker, allowing you to select a wallpaper from any directory, including ~/Pictures/wallpapers.
- The script now correctly sets the Hyprland wallpaper and updates the terminal color scheme with pywal.