### PR TITLE
fix: Correct wallpaper persistence and application

### DIFF
--- a/hypr/custom/execs.conf
+++ b/hypr/custom/execs.conf
@@ -1,5 +1,6 @@
 # You can make apps auto-start here
 # Relevant Hyprland wiki section: https://wiki.hyprland.org/Configuring/Keywords/#executing
 exec-once = vmtoolsd &
+exec-once = hyprpaper
 exec-once = ~/.config/hypr/custom/scripts/set-wallpaper.sh
 

--- a/hypr/custom/scripts/set-wallpaper.sh
+++ b/hypr/custom/scripts/set-wallpaper.sh
@@ -6,9 +6,6 @@ if ! command -v zenity &> /dev/null; then
     exit 1
 fi
 
-# Get the first monitor name
-monitor=$(hyprctl monitors | awk '/Monitor/ {print $2}')
-
 # Open file picker to select a wallpaper
 wallpaper=$(zenity --file-selection --title="Select a wallpaper" --filename="$HOME/Pictures/wallpapers/")
 
@@ -17,9 +14,14 @@ if [ -z "$wallpaper" ]; then
     exit 0
 fi
 
-# Set the wallpaper with hyprpaper
-hyprctl hyprpaper unload all
-hyprctl hyprpaper wallpaper "$monitor,$wallpaper"
+# Update hyprpaper.conf
+hyprpaper_conf="$HOME/.config/hypr/hyprpaper.conf"
+sed -i "s|^\s*wallpaper\s*=\s*.*|wallpaper = ,$wallpaper|" "$hyprpaper_conf"
+sed -i "s|^\s*preload\s*=\s*.*|preload = $wallpaper|" "$hyprpaper_conf"
+
+# Reload hyprpaper
+pkill hyprpaper
+hyprpaper &
 
 # Generate and apply color scheme with pywal
 wal -i "$wallpaper"

--- a/hypr/hyprpaper.conf
+++ b/hypr/hyprpaper.conf
@@ -1,0 +1,2 @@
+preload = ~/.config/wallpapers/mountains.jpg
+wallpaper = ,~/.config/wallpapers/mountains.jpg


### PR DESCRIPTION
This commit fixes the wallpaper setting functionality by ensuring the selected wallpaper persists across sessions and is applied correctly.

- I created a new `hyprpaper.conf` file to store the wallpaper configuration.
- I updated the `set-wallpaper.sh` script to modify this configuration file directly, ensuring that the selected wallpaper is remembered.
- The script now reloads `hyprpaper` after a new wallpaper is chosen to apply the change immediately.
- `hyprpaper` is now configured to launch on startup, ensuring the wallpaper is displayed correctly from the beginning of the session.