### PR TITLE
fix: Ensure color scheme persistence and Fuzzel theming

### DIFF
--- a/fish/config.fish
+++ b/fish/config.fish
@@ -27,3 +27,8 @@ alias q 'qs -c ii'
 #   set_color cyan; echo (pwd)
 #   set_color green; echo '> '
 # end
+
+# Load colors from pywal
+if test -f ~/.cache/wal/sequences
+    cat ~/.cache/wal/sequences | source
+end

--- a/hypr/custom/scripts/set-wallpaper.sh
+++ b/hypr/custom/scripts/set-wallpaper.sh
@@ -25,3 +25,6 @@ hyprpaper &
 
 # Generate and apply color scheme with pywal
 wal -i "$wallpaper"
+
+# Reload all themed applications
+wal -R

--- a/zsh/zshrc
+++ b/zsh/zshrc
@@ -193,3 +193,6 @@ if command -v oc &> /dev/null; then
 fi
 
 eval "$(starship init zsh)"
+
+# Load colors from pywal
+(cat ~/.cache/wal/sequences &)


### PR DESCRIPTION
This commit fixes the issues with color scheme persistence in new terminals and extends the dynamic theming to Fuzzel.

- The shell startup files (`zsh/zshrc` and `fish/config.fish`) have been modified to source the `wal` color scheme, ensuring that new terminal sessions will use the colors from the current wallpaper.
- The `set-wallpaper.sh` script has been updated to run `wal -R` after setting a new wallpaper. This command reloads all `wal`-supported applications, including Fuzzel, with the new color scheme.