### PR TITLE
fix: Correct startup behavior for wallpaper and theming

### DIFF
--- a/hypr/custom/execs.conf
+++ b/hypr/custom/execs.conf
@@ -2,5 +2,5 @@
 # Relevant Hyprland wiki section: https://wiki.hyprland.org/Configuring/Keywords/#executing
 exec-once = vmtoolsd &
 exec-once = hyprpaper
-exec-once = ~/.config/hypr/custom/scripts/set-wallpaper.sh
+exec-once = wal -R
 


### PR DESCRIPTION
This commit corrects the startup behavior to prevent the interactive wallpaper selection dialog from appearing on login and ensures that the wallpaper and color scheme persist correctly.

- The interactive `set-wallpaper.sh` script is no longer executed on startup.
- `hyprpaper` is configured to launch on startup, which automatically loads the last selected wallpaper from `hyprpaper.conf`.
- `wal -R` is now executed on startup to restore the color scheme for all supported applications, ensuring a consistent theme from the beginning of the session.