### PR TITLE
feat(hyprland): Set XDG_DATA_DIRS for better app discovery

### DIFF
--- a/hypr/custom/env.conf
+++ b/hypr/custom/env.conf
@@ -8,3 +8,4 @@ env = QT_QPA_PLATFORM,wayland
 env = QT_WAYLAND_DISABLE_WINDOWDECORATION,1
 env = MOZ_ENABLE_WAYLAND,1
 env = ILLOGICAL_IMPULSE_VIRTUAL_ENV, /home/mclellac/.local/state/quickshell/.venv
+env = XDG_DATA_DIRS, ~/.local/share/flatpak/exports/share:/var/lib/flatpak/exports/share:/usr/local/share:/usr/share


### PR DESCRIPTION
GNOME and Flatpak applications were not launching from Fuzzel because the `XDG_DATA_DIRS` environment variable was not set. This prevented Fuzzel from finding the `.desktop` files for these applications.

This change adds the `XDG_DATA_DIRS` environment variable to the Hyprland configuration, including paths for Flatpak applications. This allows Fuzzel to correctly discover and launch all applications.