### PR TITLE
fix(mutt): Correct Errors in Mutt Configuration

### DIFF
--- a/mutt/colors
+++ b/mutt/colors
@@ -11,7 +11,7 @@ color attachment   color244      color235
 color error        color204      color235
 color indicator    color223      color166
 color markers      color223      color235
-color search_highlight color184      color22
+color search       color184      color22
 color status       color250      color237
 color tilde        color244      color235
 color tree         color244      color235

--- a/mutt/keybindings
+++ b/mutt/keybindings
@@ -10,6 +10,7 @@
 # Switch between accounts
 macro index <f2> '<sync-mailbox><enter-command>source ~/.mutt/acct/personal<enter><change-folder>!<enter>' "Switch to Personal account"
 macro index <f3> '<sync-mailbox><enter-command>source ~/.mutt/acct/work<enter><change-folder>!<enter>' "Switch to Work account"
+macro generic ,r ":source ~/.mutt/muttrc\n" "Reload muttrc"
 
 # ------------------------------------------------------------------------------
 # Generic Bindings (apply in multiple views)
@@ -19,7 +20,10 @@ bind generic,index,pager q exit
 bind generic,index,pager Q quit
 bind generic,index,pager / search
 bind generic,index,pager : enter-command
-bind generic,index,pager,editor ,r ":source ~/.mutt/muttrc\n" "Reload muttrc"
+
+# Unbind keys to prevent aliasing warnings
+bind index,pager g noop
+bind index,pager d noop
 
 # Navigation
 bind generic,index,pager <PageUp>       previous-page


### PR DESCRIPTION
This commit fixes several errors that were introduced in the previous commit, which modernized the Mutt/Neomutt configuration.

The key fixes include:

- **`colors` file:** The invalid `search_highlight` color object has been replaced with the correct `search` object.

- **`keybindings` file:**
    - The `bind` command that was causing a "too many arguments" error has been corrected to a `macro`.
    - `noop` bindings have been added for the `g` and `d` keys before binding `gg` and `dd`, to prevent aliasing warnings.