### PR TITLE
fix(mutt): Correct aliasing warning for 'gg' binding

### DIFF
--- a/mutt/keybindings
+++ b/mutt/keybindings
@@ -22,6 +22,7 @@ bind generic,index,pager / search
 bind generic,index,pager : enter-command
 
 # Unbind keys to prevent aliasing warnings
+bind attach g noop
 bind index,pager g noop
 bind index,pager d noop
 


### PR DESCRIPTION
This commit fixes an aliasing warning that occurred when binding 'gg' in the attach view. The 'g' key was still bound in the attach context, causing a conflict.

The fix involves adding `bind attach g noop` to the keybindings file to unbind the 'g' key in the attach view before binding 'gg'. This is a more explicit fix than the previous attempt.