### PR TITLE
fix(mutt): Add background color to selected email

### DIFF
--- a/mutt/colors
+++ b/mutt/colors
@@ -10,7 +10,7 @@ color tree	    #89B4FA        default
 color error	    #F38BA8	default
 color message	#89B4FA    	default
 color status	#CDD6F4     #1E1E2E
-color indicator	#1E1E2E      #F9E2AF
+color indicator	#F9E2AF      #585b70
 
 # Uncolor certain messages
 uncolor index "~E"


### PR DESCRIPTION
This commit adds a background color to the indicator line in the index view. This makes it easier to see which email is currently selected.

This change is in response to your feedback that the previous color scheme made it difficult to identify the selected message.