### PR TITLE
fix(mutt): Use 256-color palette instead of hex codes

### DIFF
--- a/mutt/colors
+++ b/mutt/colors
@@ -1,16 +1,16 @@
 # vim: filetype=muttrc
 
-# Catppuccin color scheme for Mutt (Mocha flavor)
+# 256-color scheme for Mutt
 
 # Default
-color normal    #CDD6F4      default
+color normal    color252      default
 
 # Basic Colors
-color tree	    #89B4FA        default
-color error	    #F38BA8	default
-color message	#89B4FA    	default
-color status	#CDD6F4     #1E1E2E
-color indicator	#F9E2AF      #585b70
+color tree	    color111        default
+color error	    color211	default
+color message	color111    	default
+color status	color252     color235
+color indicator	color222      color240
 
 # Uncolor certain messages
 uncolor index "~E"
@@ -22,72 +22,72 @@ uncolor index "~T"
 uncolor index "~D"
 
 # Recolor them appropriately
-color index #F38BA8       default     "~E" # Expired
-color index #F5C2E7    default     "~P" # From me
-color index #A6E3A1           default     "~C @.ca"
-color index #A6E3A1          default     "~N ~u"  # new ML mail
-color index #A6E3A1         default     "~N !~u" # new non-ML mail
-color index #FAB387   default     "~T" # Tagged
-color index #F38BA8           default         "~D" # Deleted
-color index #CDD6F4         default     "~N !~T !~F !~p !~P"
-color index #CDD6F4		    default		"~A"        # all messages
-color index #BAC2DE		default		"~O"        # old messages
-color index #CBA6F7		    default		"~Q"        # messages that have been replied to
-color index #BAC2DE	    	default		"~R"        # read messages
-color index #CDD6F4           default		"~U"        # unread messages
-color index #CDD6F4           default		"~U~$"      # unread, unreferenced messages
-color index #9399B2		default		"~v"        # messages part of a collapsed thread
-color index #9399B2		default		"~P"        # messages from me
-color index #CDD6F4	        default		"~p!~F"     # messages to me
-color index #89B4FA		    default		"~N~p!~F"   # new messages to me
-color index #89B4FA		    default		"~U~p!~F"   # unread messages to me
-color index #BAC2DE	    	default		"~R~p!~F"   # messages to me
-color index #FAB387		    default		"~F"        # flagged messages
-color index #A6E3A1		    default		"~F~p"      # flagged messages to me
-color index #89B4FA		default		"~N~F"      # new flagged messages
-color index #A6E3A1		default		"~N~F~p"    # new flagged messages to me
-color index #A6E3A1 	default		"~U~F~p"    # new flagged messages to me
-color index #F38BA8		default         "~D"        # deleted messages
-color index #9399B2		default		"~v~(!~N)"  # collapsed thread with no unread
-color index #CBA6F7		default		"~v~(~N)"   # collapsed thread with some unread
-color index #A6E3A1         default		"~N~v~(~N)" # collapsed thread with unread parent
+color index color211       default     "~E" # Expired
+color index color219    default     "~P" # From me
+color index color150           default     "~C @.ca"
+color index color150          default     "~N ~u"  # new ML mail
+color index color150         default     "~N !~u" # new non-ML mail
+color index color216   default     "~T" # Tagged
+color index color211           default         "~D" # Deleted
+color index color252         default     "~N !~T !~F !~p !~P"
+color index color252		    default		"~A"        # all messages
+color index color250		default		"~O"        # old messages
+color index color183		    default		"~Q"        # messages that have been replied to
+color index color250	    	default		"~R"        # read messages
+color index color252           default		"~U"        # unread messages
+color index color252           default		"~U~$"      # unread, unreferenced messages
+color index color246		default		"~v"        # messages part of a collapsed thread
+color index color246		default		"~P"        # messages from me
+color index color252	        default		"~p!~F"     # messages to me
+color index color111		    default		"~N~p!~F"   # new messages to me
+color index color111		    default		"~U~p!~F"   # unread messages to me
+color index color250	    	default		"~R~p!~F"   # messages to me
+color index color216		    default		"~F"        # flagged messages
+color index color150		    default		"~F~p"      # flagged messages to me
+color index color111		default		"~N~F"      # new flagged messages
+color index color150		default		"~N~F~p"    # new flagged messages to me
+color index color150 	default		"~U~F~p"    # new flagged messages to me
+color index color211		default         "~D"        # deleted messages
+color index color246		default		"~v~(!~N)"  # collapsed thread with no unread
+color index color183		default		"~v~(~N)"   # collapsed thread with some unread
+color index color150         default		"~N~v~(~N)" # collapsed thread with unread parent
 
 # Header
-color header #F5C2E7  default     "^from:"
-color header #A6E3A1          default     "^to:"
-color header #F9E2AF         default     "^cc:"
-color header #89B4FA     default    "^subject:"
+color header color219  default     "^from:"
+color header color150          default     "^to:"
+color header color222         default     "^cc:"
+color header color111     default    "^subject:"
 
 # Message bodies
-color attachment #9399B2  default
-color search     #F38BA8          default
-color signature  #9399B2         default
-color tilde      #9399B2  default
-color hdrdefault #F9E2AF       default
-color bold       #F5C2E7 default
+color attachment color246  default
+color search     color211          default
+color signature  color246         default
+color tilde      color246  default
+color hdrdefault color222       default
+color bold       color219 default
 
 # URLs
-color body #89B4FA default "(^|<| )mailto:[^ ]+@[^ ]( |>|$)"
-color body #89B4FA default "(^|<| )(http|https|ftp|file|telnet|news|finger)://[^ ]+( |>|$)"
-color body #89B4FA default "([a-z][a-z0-9+-]*://(((([a-z0-9_.!~*'();:&=+$,-]|%[0-9a-f][0-9a-f])*@)?((([a-z0-9]([a-z0-9-]*[a-z0-9])?)\\.)*([a-z]([a-z0-9-]*[a-z0-9])?)\\.?|[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+)(:[0-9]+)?)|([a-z0-9_.!~*'()$,;:@&=+-]|%[0-9a-f][0-9a-f])+)(/([a-z0-9_.!~*'():@&=+$,-]|%[0-9a-f][0-9a-f])*(;([a-z0-9_.!~*'():@&=+$,-]|%[0-9a-f][0-9a-f])*)*(/([a-z0-9_.!~*'():@&=+$,-]|%[0-9a-f][0-9a-f])*(;([a-z0-9_.!~*'():@&=+$,-]|%[0-9a-f][0-9a-f])*)*)*)?(\\?([a-z0-9_.!~*'();/?:@&=+$,-]|%[0-9a-f][0-9a-f])*)?(#([a-z0-9_.!~*'();/?:@&=+$,-]|%[0-9a-f][0-9a-f])*)?|(www|ftp)\\.(([a-z0-9]([a-z0-9-]*[a-z0-9])?)\\.)*([a-z]([a-z0-9-]*[a-z0-9])?)\\.?(:[0-9]+)?(/([-a-z0-9_.!~*'():@&=+$,]|%[0-9a-f][0-9a-f])*(;([-a-z0-9_.!~*'():@&=+$,]|%[0-9a-f][0-9a-f])*)*(/([-a-z0-9_.!~*'():@&=+$,]|%[0-9a-f][0-9a-f])*(;([-a-z0-9_.!~*'():@&=+$,]|%[0-9a-f][0-9a-f])*)*)*)?(\\?([-a-z0-9_.!~*'();/?:@&=+$,]|%[0-9a-f][0-9a-f])*)?(#([-a-z0-9_.!~*'();/?:@&=+$,]|%[0-9a-f][0-9a-f])*)?)[^].,:;!)? \t\r\n<>\"]"
-color body #89B4FA  default  "((@(([0-9a-z-]+\\.)*[0-9a-z-]+\\.?|#[0-9]+|\\[[0-9]?[0-9]?[0-9]\\.[0-9]?[0-9]?[0-9]\\.[0-9]?[0-9]?[0-9]\\.[0-9]?[0-9]?[0-9]\\]),)*@(([0-9a-z-]+\\.)*[0-9a-z-]+\\.?|#[0-9]+|\\[[0-9]?[0-9]?[0-9]\\.[0-9]?[0-9]?[0-9]\\.[0-9]?[0-9]?[0-9]\\.[0-9]?[0-9]?[0-9]\\]):)?[0-9a-z_.+%$-]+@(([0-9a-z-]+\\.)*[0-9a-z-]+\\.?|#[0-9]+|\\[[0-2]?[0-9]?[0-9]\\.[0-2]?[0-9]?[0-9]\\.[0-2]?[0-9]?[0-9]\\.[0-2]?[0-9]?[0-9]\\])"
+color body color111 default "(^|<| )mailto:[^ ]+@[^ ]( |>|$)"
+color body color111 default "(^|<| )(http|https|ftp|file|telnet|news|finger)://[^ ]+( |>|$)"
+color body color111 default "([a-z][a-z0-9+-]*://(((([a-z0-9_.!~*'();:&=+$,-]|%[0-9a-f][0-9a-f])*@)?((([a-z0-9]([a-z0-9-]*[a-z0-9])?)\\.)*([a-z]([a-z0-9-]*[a-z0-9])?)\\.?|[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+)(:[0-9]+)?)|([a-z0-9_.!~*'()$,;:@&=+-]|%[0-9a-f][0-9a-f])+)(/([a-z0-9_.!~*'():@&=+$,-]|%[0-9a-f][0-9a-f])*(;([a-z0-9_.!~*'():@&=+$,-]|%[0-9a-f][0-9a-f])*)*(/([a-z0-9_.!~*'():@&=+$,-]|%[0-9a-f][0-9a-f])*(;([a-z0-9_.!~*'():@&=+$,-]|%[0-9a-f][0-9a-f])*)*)*)?(\\?([a-z0-9_.!~*'();/?:@&=+$,-]|%[0-9a-f][0-9a-f])*)?(#([a-z0-9_.!~*'();/?:@&=+$,-]|%[0-9a-f][0-9a-f])*)?|(www|ftp)\\.(([a-z0-9]([a-z0-9-]*[a-z0-9])?)\\.)*([a-z]([a-z0-9-]*[a-z0-9])?)\\.?(:[0-9]+)?(/([-a-z0-9_.!~*'():@&=+$,]|%[0-9a-f][0-9a-f])*(;([-a-z0-9_.!~*'():@&=+$,]|%[0-9a-f][0-9a-f])*)*(/([-a-z0-9_.!~*'():@&=+$,]|%[0-9a-f][0-9a-f])*(;([-a-z0-9_.!~*'():@&=+$,]|%[0-9a-f][0-9a-f])*)*)*)?(\\?([-a-z0-9_.!~*'();/?:@&=+$,]|%[0-9a-f][0-9a-f])*)?(#([-a-z0-9_.!~*'();/?:@&=+$,]|%[0-9a-f][0-9a-f])*)?)[^].,:;!)? \t\r\n<>\"]"
+color body color111  default  "((@(([0-9a-z-]+\\.)*[0-9a-z-]+\\.?|#[0-9]+|\\[[0-9]?[0-9]?[0-9]\\.[0-9]?[0-9]?[0-9]\\.[0-9]?[0-9]?[0-9]\\.[0-9]?[0-9]?[0-9]\\]),)*@(([0-9a-z-]+\\.)*[0-9a-z-]+\\.?|#[0-9]+|\\[[0-9]?[0-9]?[0-9]\\.[0-9]?[0-9]?[0-9]\\.[0-9]?[0-9]?[0-9]\\.[0-9]?[0-9]?[0-9]\\]):)?[0-9a-z_.+%$-]+@(([0-9a-z-]+\\.)*[0-9a-z-]+\\.?|#[0-9]+|\\[[0-2]?[0-9]?[0-9]\\.[0-2]?[0-9]?[0-9]\\.[0-2]?[0-9]?[0-9]\\.[0-2]?[0-9]?[0-9]\\])"
 
 # *bold*, _underline_, and /italic/
-color body #F5C2E7 default "(^| )\\*[^ ]+\\*( |$)"
-color body #A6E3A1 default "(^| )_[^ ]+_( |$)"
-color body #CBA6F7 default "(^| )/[^ ]+/( |$)"
+color body color219 default "(^| )\\*[^ ]+\\*( |$)"
+color body color150 default "(^| )_[^ ]+_( |$)"
+color body color183 default "(^| )/[^ ]+/( |$)"
 
 # Quoted text
-color quoted  #CBA6F7 default
-color quoted1 #89B4FA          default
-color quoted2 #A6E3A1         default
-color quoted3 #F9E2AF        default
-color quoted4 #F5C2E7       default
-color quoted5 #A6E3A1   default
-color quoted6 #F9E2AF  default
-color quoted7 #89B4FA    default
+color quoted  color183 default
+color quoted1 color111          default
+color quoted2 color150         default
+color quoted3 color222        default
+color quoted4 color219       default
+color quoted5 color150   default
+color quoted6 color222  default
+color quoted7 color111    default
 
 # PGP messages
-color body #A6E3A1     default     "^gpg signature OK.*"
-color body #F9E2AF          default     "^gpg "
-color body #F38BA8       default     "^gpg signature NOT OK. *"
+color body color150     default     "^gpg signature OK.*"
+color body color222          default     "^gpg "
+color body color211       default     "^gpg signature NOT OK. *"


### PR DESCRIPTION
This commit fixes the "Direct colors support disabled" errors by replacing all hex color codes in the `colors` file with their closest equivalents from the 256-color palette.

This ensures that your color scheme is compatible with terminals that do not support truecolor.