### PR TITLE
feat(mutt): Update nerd font glyphs in format strings

### DIFF
--- a/mutt/formats
+++ b/mutt/formats
@@ -1,10 +1,8 @@
 # status format
-# ------------------------------------------------------------------------------
 # %b number of mailboxes with new mail *
 # %d number of deleted messages *
 # %f the full pathname of the current mailbox
 # %F number of flagged messages *
-# %h local hostname
 # %l size (in bytes) of the current mailbox *
 # %L size (in bytes) of the messages shown (i.e., which match the current limit) *
 # %m the number of messages in the mailbox *
@@ -22,24 +20,15 @@
 # %V currently active limit pattern, if any *
 # %>X right justify the rest of the string and pad with "X"
 # %|X pad to the end of the line with "X"
-# (*) can be optionally printed if non-zero
-# ------------------------------------------------------------------------------
 #set status_format="-%r-Mutt: %f [Msgs:%?M?%M/?%m%?n? New:%n?%?o? Old:%o?%?d? Del:%d?%?F? Flag:%F?%?t? Tag:%t?%?p? Post:%p?%?b? Inc:%b? %?l? %l?]---(%s/%S)-%>-(%P)---"
-set status_format= " %?M?%M/?%m  Mails %?n?%n  new, ?%?u?%u  unread, ?%?p?%p  drafts, ?%?t?%t  +tagged, ?%?d?%d  deleted, ? %f %> %V  [%P]"
-
-# folder format
-# ------------------------------------------------------------------------------
-set folder_format= " %2C %t %N %2s %d %f" # mailbox list view
-
-# index / forward / message / pager format 
-# ---------------------------------------------------------------------------------------------------------
+set status_format= " %?M?%M/?%m  Mails %?n?%n  new, ?%?u?%u  unread, ?%?p?%p  drafts, ?%?t?%t  +tagged, ?%?d?%d  deleted, ? %f %> %V  [%P]"
+set folder_format= " %2C %t %N %2s %d %f" # mailbox list view
 # %a address of the author
 # %A reply-to address (if present; otherwise: address of author)
 # %b filename of the original message folder (think mailBox)
 # %B the list to which the letter was sent, or else the folder name (%b).
 # %c number of characters (bytes) in the message
 # %C current message number
-# %d date and time of the message in the format specified by ``date_format'' converted to sender's time zone
 # %D date and time of the message in the format specified by ``date_format'' converted to the local time zone
 # %e current message number in thread
 # %E number of messages in current thread
@@ -69,73 +58,43 @@ set folder_format= " %2C %t %N %2s %d %f" # mailbox list view
 # %[fmt] the date and time of the message is converted to the local time zone, and ``fmt'' is expanded by the library function
 #        ``strftime''; a leading bang disables locales
 # %(fmt) the local date and time when the message was received. ``fmt'' is expanded by the library function ``strftime''; a leading
-#        bang disables locales
 # %<fmt> the current local time. ``fmt'' is expanded by the library function ``strftime''; a leading bang disables locales.
 # %>X right justify the rest of the string and pad with character "X"
 # %|X pad to the end of the line with character "X"
-# ------------------------------------------------------------------------------
 #set index_format="%3C %Z %[!%m.%d.%y] %-19.19n - %?X?%X& ? %?M?*%M*&%02e/%02E? %s%> %?y?[%Y]?"
 #set index_format="%Z %D • %-25.25L • %s"
 #set index_format="%D    %-20.20L %s %> %c"
-set index_format="%S   • %D   %-20.20L  %T %s"
-
+set index_format="%S   • %D   %-20.20L  %T %s"
 #set forward_format="[%a: %:ws]"
 set forward_format="Fwd: %s"
-
 set message_format="%s"
-
 #set pager_format="-%Z- %C/%m: %-20.20n   %s"
 #set pager_format="%S [%C/%T] %l %n %s"
 #set pager_format="%s %>  (%c)"
-set pager_format= " Message %C %> (%P)"  # pager statusbar
-
-# compose format
-# -------------------------------------------------------------------------------
+set pager_format= " Message %C %> (%P)"  # pager statusbar
 # %a total number of attachments
-# %h local hostname
 # %l approximate size (in bytes) of the current message
 # %v Mutt version string
-# ------------------------------------------------------------------------------
-set compose_format=" Compose [Approx. msg size:  %l Atts: %a]%>-"
-
-#  date format 
-# ------------------------------------------------------------------------------
+set compose_format=" Compose [Approx. msg size:  %l Atts: %a]%>-"
 # (man strftime(3)
-# ------------------------------------------------------------------------------
 #set date_format="!%a, %b %d, %Y at %I:%M:%S%p %Z"
 set date_format= "[%m/%d %I:%M%P]"
-
-# alias format
-# --------------------
-# %a alias name
 # %f flags - currently, a "d" for an alias marked for deletion
 # %n index number
-# %r address which alias expands to
 # %t character which indicates if the alias is tagged for inclusion
-# ------------------------------------------------------------------------------
-set alias_format="   %4n %2f %t %-10a %r"
-
-# attach format 
-# ------------------------------------------------------------------------------
+set alias_format="   %4n %2f %t %-10a %r"
 # %C charset
 # %c requires charset conversion (n or c)
 # %D deleted flag
-# %d description
 # %e MIME content-transfer-encoding
-# %f filename
 # %I disposition (I=inline, A=attachment)
 # %m major MIME type
 # %M MIME subtype
 # %n attachment number
 # %Q "Q", if MIME part qualifies for attachment counting
-# %s size
-# %t tagged flag
 # %T graphic tree characters
 # %u unlink (=to delete) flag
 # %X number of qualifying MIME parts in this part and its children
-#    (please see the ``attachments'' section for possible speed
-#    effects)
 # %>X right justify the rest of the string and pad with character "X"
 # %|X pad to the end of the line with character "X"
-###
-set attach_format=" %u%D%I %t%4n  %T%.40d%> [%.7m/%.10M, %.6e%?C?,  %C?] "
+set attach_format=" %u%D%I %t%4n  %T%.40d%> [%.7m/%.10M, %.6e%?C?,  %C?] "


### PR DESCRIPTION
This commit updates the nerd font glyphs used in the `mutt/formats` file to improve their appearance and ensure they are rendered correctly.

The new glyphs are more representative of the functions they represent and have been chosen from the Font Awesome collection within Nerd Fonts.