### PR TITLE
feat(mutt): Add domain-specific colors to email index

### DIFF
--- a/mutt/colors
+++ b/mutt/colors
@@ -91,3 +91,12 @@ color quoted7 color111    default
 color body color150     default     "^gpg signature OK.*"
 color body color222          default     "^gpg "
 color body color211       default     "^gpg signature NOT OK. *"
+
+# Domain-specific colors
+color index color111 default "~f gmail.com"
+color index color150 default "~f work.com"
+color index color222 default "~f newsletter.com"
+color index color197 default "~f rogers.com"
+color index color161 default "~f cibc.com"
+color index color117 default "~f steam.com"
+color index color114 default "~f wealthsimple.com"


### PR DESCRIPTION
This commit adds domain-specific color highlighting to the email index. This allows for easy identification of emails from different sources.

The following domains have been added with custom colors:
- gmail.com
- work.com
- newsletter.com
- rogers.com
- cibc.com
- steam.com
- wealthsimple.com