### PR TITLE
feat(waybar): Update calendar, icons, and workspaces

### DIFF
--- a/waybar/config.jsonc
+++ b/waybar/config.jsonc
@@ -14,13 +14,13 @@
     "pulseaudio",
   ],
   "hyprland/workspaces": {
-    "format": "{name} {icon}",
+    "format": "{icon}",
     "format-icons": {
-      "1": "",
-      "2": "",
-      "3": "",
-      "4": "",
-      "5": "",
+      "SHELL": "",
+      "WEB": "",
+      "CODE": "",
+      "COMMS": "",
+      "MISC": "",
       "active": "",
       "default": ""
     },
@@ -33,11 +33,11 @@
     "tooltip": false
   },
   "clock": {
-    "format": "{:%H:%M}  ",
+    "format": "{:%H:%M} 󰥔 ",
     "format-alt": "{:%A, %B %d, %Y (%R)}  ",
     "tooltip-format": "<tt><small>{calendar}</small></tt>",
     "calendar": {
-      "mode": "year",
+      "mode": "month",
       "mode-mon-col": 3,
       "weeks-pos": "right",
       "on-scroll": 1,
@@ -98,7 +98,7 @@
       "phone": "󰏲",
       "portable": "󰏲",
       "car": "󰄋",
-      "default": ["", "", ""]
+      "default": ["󰕿", "󰖀", "󰕾"]
     }
   },
   "pulseaudio#microphone": {

--- a/waybar/themes/adw-dark.css
+++ b/waybar/themes/adw-dark.css
@@ -217,6 +217,7 @@ calendar {
     padding: 10px;
     border: 1px solid @tooltip-border;
     background-color: @tooltip-bg;
+    font-size: 22px;
 }
 
 calendar.header {


### PR DESCRIPTION
This commit addresses your follow-up requests to the waybar configuration and theme.

Changes include:
- The calendar now only shows the current month and is larger and easier to read.
- The Nerd Font icons have been updated again to fix issues with the previous set.
- The workspace display now only shows the icons with the names SHELL, WEB, CODE, COMMS, MISC.