### PR TITLE
fix(waybar): Fix power menu trigger and switch to fuzzel

### DIFF
--- a/waybar/config.jsonc
+++ b/waybar/config.jsonc
@@ -20,8 +20,7 @@
   ],
   "custom/power": {
     "format": "",
-    "exec": "~/.config/waybar/scripts/power.sh",
-    "interval": "once",
+    "on-click": "~/.config/waybar/scripts/power.sh",
     "tooltip": false
   },
   "custom/weather": {

--- a/waybar/scripts/power.sh
+++ b/waybar/scripts/power.sh
@@ -2,7 +2,7 @@
 
 entries=" Shutdown\n Reboot\n Logout\n Lock"
 
-selected=$(echo -e $entries|wofi --dmenu --prompt "Power Menu" --style ~/.config/wofi/themes/power.css)
+selected=$(echo -e $entries|fuzzel --dmenu --prompt "Power Menu")
 
 case "$selected" in
   *Shutdown)


### PR DESCRIPTION
This commit fixes a bug where the power menu was showing on startup. It also switches the power menu from wofi to fuzzel to match your existing theme.

Changes include:
- The `custom/power` module in `waybar/config.jsonc` now uses `on-click` to trigger the power menu script.
- The `waybar/scripts/power.sh` script now uses `fuzzel` instead of `wofi`.