### PR TITLE
fix(waybar): Replace weather script with a more reliable one

### DIFF
--- a/waybar/scripts/weather.sh
+++ b/waybar/scripts/weather.sh
@@ -1,10 +1,27 @@
 #!/bin/sh
 
-WEATHER_DATA=$(curl -sf "https://www.theweathernetwork.com/en/city/ca/ontario/toronto/current")
+# Use wttr.in for weather data, which is more reliable than scraping
+WEATHER_DATA=$(curl -sf "wttr.in/Toronto?format=j1")
 
 if [ -n "$WEATHER_DATA" ]; then
-    WEATHER_TEMP=$(echo "$WEATHER_DATA" | grep -A 1 '\[[0-9]\+\.svg\]' | tail -n 1 | sed 's/ //g')
-    WEATHER_CONDITION=$(echo "$WEATHER_DATA" | grep -A 2 '\[[0-9]\+\.svg\]' | tail -n 1 | sed 's/ //g')
+    WEATHER_TEMP=$(echo "$WEATHER_DATA" | jq -r ".current_condition[0].temp_C")
+    WEATHER_DESC=$(echo "$WEATHER_DATA" | jq -r ".current_condition[0].weatherDesc[0].value")
 
-    echo "{\"text\": \"$WEATHER_TEMP°C\", \"tooltip\": \"$WEATHER_CONDITION\"}"
+    # Simple icon mapping
+    ICON="?"
+    case "$WEATHER_DESC" in
+        *Sunny*) ICON="☀️";;
+        *Clear*) ICON="☀️";;
+        *Cloudy*) ICON="☁️";;
+        *Partly*cloudy*) ICON="⛅️";;
+        *Rain*) ICON="🌧️";;
+        *Snow*) ICON="❄️";;
+        *Mist*) ICON="🌫️";;
+        *) ICON="";; # A generic cloud icon
+    esac
+
+    # Waybar JSON output
+    echo "{\"text\": \"$ICON $WEATHER_TEMP°C\", \"tooltip\": \"$WEATHER_DESC\"}"
+else
+    echo "{\"text\": \"Weather N/A\", \"tooltip\": \"Could not fetch weather\"}"
 fi


### PR DESCRIPTION
The previous weather script was based on scraping a website and was not reliable. This commit replaces it with a new script that uses the `wttr.in` service, which provides a JSON API for weather data. This should be much more stable.

The new script:
- Fetches weather data from `wttr.in/Toronto?format=j1`.
- Parses the JSON response using `jq`.
- Displays the temperature and a weather icon.
- Provides the weather description in the tooltip.