### PR TITLE
fix(waybar): Correct weather display and update clock format

### DIFF
--- a/waybar/config.jsonc
+++ b/waybar/config.jsonc
@@ -26,7 +26,8 @@
   "custom/weather": {
     "exec": "~/.config/waybar/scripts/weather.sh",
     "interval": 1800,
-    "tooltip": true
+    "tooltip": true,
+    "format": "{}"
   },
   "hyprland/workspaces": {
     "format": "{icon}",
@@ -48,8 +49,8 @@
     "tooltip": false
   },
   "clock": {
-    "format": "{:%H:%M} 󰥔 ",
-    "format-alt": "{:%A, %B %d, %Y (%R)}  ",
+    "format": "{:%I:%M %p} 󰥔 ",
+    "format-alt": "{:%A, %B %d, %Y (%R)}  ",
     "tooltip-format": "<tt><small>{calendar}</small></tt>",
     "calendar": {
       "mode": "month",


### PR DESCRIPTION
This commit addresses several issues you reported regarding the Waybar configuration.

Changes include:
- The `custom/weather` module is fixed to correctly parse and display the output from the weather script by adding `format: {}`.
- The main clock format is changed to a 12-hour AM/PM format.
- The Nerd Font icon in the alternate clock format has been replaced with one that should render correctly.