### PR TITLE
fix(waybar): Ensure weather script produces valid JSON

### DIFF
--- a/waybar/scripts/weather.sh
+++ b/waybar/scripts/weather.sh
@@ -4,11 +4,12 @@
 WEATHER_DATA=$(curl -sf "wttr.in/Toronto?format=j1")
 
 if [ -n "$WEATHER_DATA" ]; then
+    # Safely extract data
     WEATHER_TEMP=$(echo "$WEATHER_DATA" | jq -r ".current_condition[0].temp_C")
     WEATHER_DESC=$(echo "$WEATHER_DATA" | jq -r ".current_condition[0].weatherDesc[0].value")
 
-    # Simple icon mapping
-    ICON="?"
+    # Icon mapping
+    ICON="" # Default icon
     case "$WEATHER_DESC" in
         *Sunny*) ICON="☀️";;
         *Clear*) ICON="☀️";;
@@ -17,11 +18,13 @@ if [ -n "$WEATHER_DATA" ]; then
         *Rain*) ICON="🌧️";;
         *Snow*) ICON="❄️";;
         *Mist*) ICON="🌫️";;
-        *) ICON="";; # A generic cloud icon
     esac
 
-    # Waybar JSON output
-    echo "{\"text\": \"$ICON $WEATHER_TEMP°C\", \"tooltip\": \"$WEATHER_DESC\"}"
+    TEXT_CONTENT="$ICON $WEATHER_TEMP°C"
+
+    # Use jq to safely construct the JSON output
+    jq -n --arg text "$TEXT_CONTENT" --arg tooltip "$WEATHER_DESC" '{"text": $text, "tooltip": $tooltip}'
 else
-    echo "{\"text\": \"Weather N/A\", \"tooltip\": \"Could not fetch weather\"}"
+    # Fallback JSON
+    jq -n '{"text": "Weather N/A", "tooltip": "Could not fetch weather"}'
 fi


### PR DESCRIPTION
The previous weather script was unreliable and could produce invalid JSON, causing Waybar to display the raw text.

This commit rewrites the script to use `jq` to construct the JSON output. This guarantees that the output sent to Waybar is always well-formed, resolving the display issue. The script continues to use `wttr.in` for reliable weather data.