### PR TITLE
fix(waybar): Correctly configure custom weather module

### DIFF
--- a/waybar/config.jsonc
+++ b/waybar/config.jsonc
@@ -26,8 +26,7 @@
   "custom/weather": {
     "exec": "~/.config/waybar/scripts/weather.sh",
     "interval": 1800,
-    "tooltip": true,
-    "format": "{}"
+    "tooltip": true
   },
   "hyprland/workspaces": {
     "format": "{icon}",


### PR DESCRIPTION
This commit fixes a bug where the custom weather module was displaying raw JSON text.

The previous configuration included a `format: {}` property, which was interfering with Waybar's automatic parsing of the JSON object produced by the script.

By removing the `format` key, Waybar can now correctly detect and parse the JSON from the `exec` script, displaying the `text` and `tooltip` fields as intended.