### PR TITLE
Fix(hypr): Resolve config conflict preventing color and plugin loading

### DIFF
--- a/hypr/hyprland/general.conf
+++ b/hypr/hyprland/general.conf
@@ -24,8 +24,8 @@ general {
     gaps_workspaces = 50
     
     border_size = 3
-    col.active_border = rgba(0DB7D4FF)
-    col.inactive_border = rgba(31313600)
+    # col.active_border = rgba(0DB7D4FF)
+    # col.inactive_border = rgba(31313600)
     resize_on_border = true
 
     no_focus_fallback = true


### PR DESCRIPTION
The border colors and hyprbar settings were not being applied because of a configuration conflict.

The default `hypr/hyprland/general.conf` defined a `general` block with static colors. This appeared to conflict with the `general` block in `hypr/hyprland/colors.conf`, preventing the latter file from being parsed correctly and its settings (including the `hyprbar` plugin config) from being applied.

This commit resolves the issue by commenting out the static `col.active_border` and `col.inactive_border` definitions in `hypr/hyprland/general.conf`. This removes the conflict and allows the settings from `hypr/hyprland/colors.conf` to be loaded as intended.