### PR TITLE
Fix(hypr): Move plugin configs to main hyprland.conf to ensure they load

### DIFF
--- a/hypr/hyprland.conf
+++ b/hypr/hyprland.conf
@@ -19,3 +19,44 @@ source=~/.config/hypr/custom/execs.conf
 source=~/.config/hypr/custom/general.conf
 source=~/.config/hypr/custom/rules.conf
 source=~/.config/hypr/custom/keybinds.conf
+
+
+# PLUGINS
+# Note: Plugins are loaded here directly because they were not loading from sourced files.
+
+# hyprexpo from hypr/hyprland/general.conf
+plugin {
+    hyprexpo {
+        columns = 3
+        gap_size = 5
+        bg_col = rgb(000000)
+        workspace_method = first 1 # [center/first] [workspace] e.g. first 1 or center m+1
+
+        enable_gesture = false # laptop touchpad, 4 fingers
+        gesture_distance = 300 # how far is the "max"
+        gesture_positive = false
+    }
+}
+
+# hyprbars from hypr/hyprland/colors.conf
+plugin {
+    hyprbars {
+        # Honestly idk if it works like css, but well, why not
+        bar_text_font = Rubik, Geist, AR One Sans, Reddit Sans, Inter, Roboto, Ubuntu, Noto Sans, sans-serif
+        bar_height = 30
+        bar_padding = 10
+        bar_button_padding = 5
+        bar_precedence_over_border = true
+        bar_part_of_window = true
+
+        bar_color = rgba(1D1011FF)
+        col.text = rgba(F7DCDEFF)
+
+
+        # example buttons (R -> L)
+        # hyprbars-button = color, size, on-click
+        hyprbars-button = rgb(F7DCDE), 13, 󰖭, hyprctl dispatch killactive
+        hyprbars-button = rgb(F7DCDE), 13, 󰖯, hyprctl dispatch fullscreen 1
+        hyprbars-button = rgb(F7DCDE), 13, 󰖰, hyprctl dispatch movetoworkspacesilent special
+    }
+}

--- a/hypr/hyprland/colors.conf
+++ b/hypr/hyprland/colors.conf
@@ -9,26 +9,5 @@ misc {
     background_color = rgba(1D1011FF)
 }
 
-plugin {
-    hyprbars {
-        # Honestly idk if it works like css, but well, why not
-        bar_text_font = Rubik, Geist, AR One Sans, Reddit Sans, Inter, Roboto, Ubuntu, Noto Sans, sans-serif
-        bar_height = 30
-        bar_padding = 10
-        bar_button_padding = 5
-        bar_precedence_over_border = true
-        bar_part_of_window = true
-
-        bar_color = rgba(1D1011FF)
-        col.text = rgba(F7DCDEFF)
-
-
-        # example buttons (R -> L)
-        # hyprbars-button = color, size, on-click
-        hyprbars-button = rgb(F7DCDE), 13, 󰖭, hyprctl dispatch killactive
-        hyprbars-button = rgb(F7DCDE), 13, 󰖯, hyprctl dispatch fullscreen 1
-        hyprbars-button = rgb(F7DCDE), 13, 󰖰, hyprctl dispatch movetoworkspacesilent special
-    }
-}
 
 windowrulev2 = bordercolor rgba(FFB2BCAA) rgba(FFB2BC77),pinned:1

--- a/hypr/hyprland/general.conf
+++ b/hypr/hyprland/general.conf
@@ -154,15 +154,3 @@ cursor {
 }
 
 # Overview
-plugin {
-    hyprexpo {
-        columns = 3
-        gap_size = 5
-        bg_col = rgb(000000)
-        workspace_method = first 1 # [center/first] [workspace] e.g. first 1 or center m+1
-
-        enable_gesture = false # laptop touchpad, 4 fingers
-        gesture_distance = 300 # how far is the "max"
-        gesture_positive = false
-    }
-}


### PR DESCRIPTION
The previous fix was not successful. The user reported that `hyprctl plugin list` was empty, which indicated that Hyprland was not loading any plugins from the sourced configuration files.

This commit addresses the issue by moving the `hyprexpo` and `hyprbars` plugin configurations from `general.conf` and `colors.conf` respectively, and placing them directly into the main `hyprland.conf`.

This change is based on the hypothesis that Hyprland only processes plugin blocks found in the main configuration file, not in files included via the `source` directive. This should allow both plugins to be loaded correctly. The previous change to comment out the conflicting border colors in `general.conf` has been kept to ensure the colors from `colors.conf` are applied as intended.