### PR TITLE
feat: Update hyprland and add foot config

### DIFF
--- a/foot/foot.ini
+++ b/foot/foot.ini
@@ -1,0 +1,61 @@
+# -*- conf -*-
+
+# shell=$SHELL (if set, otherwise user's default shell from /etc/passwd)
+# term=foot
+# login-shell=no
+
+# app-id=foot
+# title=foot
+# locked-title=no
+
+[main]
+font=Fira Code:size=10
+# letter-spacing=0
+# line-height=120%
+# initial-window-size-pixels=700x500
+# initial-window-size-chars=80x24
+# initial-window-mode=windowed
+pad=10x10
+
+[scrollback]
+lines=10000
+
+[colors]
+alpha=0.9
+background=0d1b2a
+foreground=c0c5ce
+
+## Normal
+regular0=1e222a  # black
+regular1=ff5555  # red
+regular2=50fa7b  # green
+regular3=f1fa8c  # yellow
+regular4=bd93f9  # blue
+regular5=ff79c6  # magenta
+regular6=8be9fd  # cyan
+regular7=f8f8f2  # white
+
+## Bright
+bright0=6272a4   # black
+bright1=ff6e6e   # red
+bright2=69ff94   # green
+bright3=ffffa5   # yellow
+bright4=d6acff   # blue
+bright5=ff92df   # magenta
+bright6=a4ffff   # cyan
+bright7=ffffff   # white
+
+[cursor]
+# color=...
+style=beam
+# blink=no
+
+[mouse]
+hide-when-typing=yes
+
+[key-bindings]
+scrollback-up-page=Shift+Page_Up
+scrollback-down-page=Shift+Page_Down
+clipboard-paste=Control+Shift+v
+clipboard-copy=Control+Shift+c
+primary-paste=Shift+Insert

--- a/hypr/hyprland/colors.conf
+++ b/hypr/hyprland/colors.conf
@@ -1,13 +1,10 @@
-# exec = export SLURP_ARGS='-d -c FFDAD4BB -b 673B3444 -s 00000000'
-
 general {
-    col.active_border = rgba(F7DCDE39)
-    col.inactive_border = rgba(A58A8D30)
+    col.active_border = rgba(ff8800FF)
+    col.inactive_border = rgba(415a77FF)
 }
 
 misc {
-    background_color = rgba(1D1011FF)
+    background_color = rgba(0d1b2aFF)
 }
 
-
-windowrulev2 = bordercolor rgba(FFB2BCAA) rgba(FFB2BC77),pinned:1
+windowrulev2 = bordercolor rgba(ff8800AA) rgba(ff880077),pinned:1

--- a/hypr/hyprland/rules.conf
+++ b/hypr/hyprland/rules.conf
@@ -78,6 +78,11 @@ windowrulev2 = immediate, class:^(steam_app).*
 # No shadow for tiled windows (matches windows that are not floating).
 windowrulev2 = noshadow, floating:0
 
+
+# Hyprbars on terminals only
+windowrulev2 = plugin:hyprbars:nobar, class:^(?!kitty|foot|ptyxis|blackbox).*$
+
+
 # ######## Workspace rules ########
 workspace = special:special, gapsout:30
 


### PR DESCRIPTION
This commit introduces several changes to the hyprland configuration and adds a new configuration for the foot terminal.

Hyprland:
- Updated the window rules to only show hyprbars on terminal applications (kitty, foot, ptyxis, blackbox).
- Changed the color scheme to a blue and orange theme.

Foot:
- Added a new configuration file for the foot terminal with a modern, dark, and slick theme that matches the new hyprland colors.