### PR TITLE
feat: Update hyprland and add foot config

### DIFF
--- a/hypr/hyprland/rules.conf
+++ b/hypr/hyprland/rules.conf
@@ -79,8 +79,22 @@ windowrulev2 = immediate, class:^(steam_app).*
 windowrulev2 = noshadow, floating:0
 
 
-# Hyprbars on terminals only
-windowrulev2 = plugin:hyprbars:nobar, class:^(?!kitty|foot|ptyxis|blackbox).*$
+# --- Hyprbars ---
+# The hyprbars plugin does not have a rule to *enable* the bar, only to disable it.
+# This means we cannot disable it globally and then enable it for terminals.
+# Instead, we disable it for common non-terminal applications.
+# You may need to add more rules here for your own applications.
+windowrulev2 = plugin:hyprbars:nobar, class:^(firefox)$
+windowrulev2 = plugin:hyprbars:nobar, class:^(Chrome)$
+windowrulev2 = plugin:hyprbars:nobar, class:^(Chromium)$
+windowrulev2 = plugin:hyprbars:nobar, class:^(thunar)$
+windowrulev2 = plugin:hyprbars:nobar, class:^(nautilus)$
+windowrulev2 = plugin:hyprbars:nobar, class:^(dolphin)$
+windowrulev2 = plugin:hyprbars:nobar, class:^(code)$
+windowrulev2 = plugin:hyprbars:nobar, class:^(vscodium)$
+windowrulev2 = plugin:hyprbars:nobar, class:^(discord)$
+windowrulev2 = plugin:hyprbars:nobar, class:^(steam)$
+windowrulev2 = plugin:hyprbars:nobar, class:^(spotify)$
 
 
 # ######## Workspace rules ########


### PR DESCRIPTION
This commit introduces several changes to the hyprland configuration and adds a new configuration for the foot terminal.

Hyprland:
- Updated the window rules to only show hyprbars on terminal applications. This is achieved by disabling hyprbars on a list of common non-terminal applications.
- Changed the color scheme to a blue and orange theme.

Foot:
- Added a new configuration file for the foot terminal with a modern, dark, and slick theme that matches the new hyprland colors.