### PR TITLE
feat: Update hyprland and add foot config

### DIFF
--- a/hypr/hyprland.conf
+++ b/hypr/hyprland.conf
@@ -49,14 +49,14 @@ plugin {
         bar_precedence_over_border = true
         bar_part_of_window = true
 
-        bar_color = rgba(1D1011FF)
-        col.text = rgba(F7DCDEFF)
+        bar_color = rgba(0d1b2aFF)
+        col.text = rgba(c0c5ceFF)
 
 
         # example buttons (R -> L)
         # hyprbars-button = color, size, on-click
-        hyprbars-button = rgb(F7DCDE), 13, 󰖭, hyprctl dispatch killactive
-        hyprbars-button = rgb(F7DCDE), 13, 󰖯, hyprctl dispatch fullscreen 1
-        hyprbars-button = rgb(F7DCDE), 13, 󰖰, hyprctl dispatch movetoworkspacesilent special
+        hyprbars-button = rgb(ff8800), 13, 󰖭, hyprctl dispatch killactive
+        hyprbars-button = rgb(ff8800), 13, 󰖯, hyprctl dispatch fullscreen 1
+        hyprbars-button = rgb(ff8800), 13, 󰖰, hyprctl dispatch movetoworkspacesilent special
     }
 }

--- a/waybar/themes/style.css
+++ b/waybar/themes/style.css
@@ -8,8 +8,8 @@
 }
 
 window#waybar {
-    background: rgba(29, 16, 17, 0.8);
-    color: #F7DCDE;
+    background: rgba(13, 27, 42, 0.8);
+    color: #c0c5ce;
 }
 
 #workspaces,
@@ -19,7 +19,9 @@ window#waybar {
 #memory,
 #battery,
 #network,
-#pulseaudio {
+#pulseaudio,
+#custom-weather,
+#custom-power {
     padding: 2px 10px;
     margin: 8px 4px;
 }
@@ -30,44 +32,40 @@ window#waybar {
 
 #workspaces button {
     padding: 2px 5px;
-    color: #A58A8D;
+    color: #415a77;
     background-color: transparent;
 }
 
 #workspaces button.focused {
-    color: #F7DCDE;
-    background-color: #A58A8D;
+    color: #0d1b2a;
+    background-color: #ff8800;
     border-radius: 10px;
 }
 
 #workspaces button.urgent {
-    color: #1D1011;
-    background-color: #FFB2BC;
+    color: #0d1b2a;
+    background-color: #ff5555; /* A red for urgent */
     border-radius: 10px;
 }
 
-#clock {
-    color: #F7DCDE;
-}
-
-#tray {
-    background-color: transparent;
-}
-
+#clock,
+#tray,
 #battery,
 #cpu,
 #memory,
 #network,
-#pulseaudio {
-    color: #F7DCDE;
+#pulseaudio,
+#custom-weather,
+#custom-power {
+    color: #c0c5ce;
 }
 
 #battery.charging,
 #battery.plugged {
-    color: #89b4fa; /* A different color to indicate charging */
+    color: #89b4fa; /* A light blue to indicate charging */
 }
 
 #battery.critical:not(.charging) {
-    background-color: #f38ba8;
-    color: #1e1e2e;
+    background-color: #ff5555;
+    color: #0d1b2a;
 }


### PR DESCRIPTION
This commit introduces several changes to the hyprland configuration and adds a new configuration for the foot terminal.

Hyprland:
- Updated the window rules to only show hyprbars on terminal applications. This is achieved by disabling hyprbars on a list of common non-terminal applications.
- Changed the color scheme to a blue and orange theme. This includes the main hyprland colors, the hyprbar plugin, and the waybar theme.

Foot:
- Added a new configuration file for the foot terminal with a modern, dark, and slick theme that matches the new hyprland colors.