### PR TITLE
feat: update color scheme for hyprland, waybar, and fuzzel

### DIFF
--- a/fuzzel/fuzzel.ini
+++ b/fuzzel/fuzzel.ini
@@ -6,12 +6,12 @@ terminal=kitty
 prompt=" "
 
 [colors]
-background=1D1011ff
-text=F7DCDEff
-match=FFB2BCff
-selection=A58A8Dff
-selection-text=1D1011ff
-border=FFB2BCff
+background=1a1b26ff
+text=c0caf5ff
+match=7aa2f7ff
+selection=414868ff
+selection-text=c0caf5ff
+border=7aa2f7ff
 
 [border]
 width=2

--- a/hypr/hyprland.conf
+++ b/hypr/hyprland.conf
@@ -49,14 +49,14 @@ plugin {
         bar_precedence_over_border = true
         bar_part_of_window = true
 
-        bar_color = rgba(0d1b2aFF)
-        col.text = rgba(c0c5ceFF)
+        bar_color = $background
+        col.text = $foreground
 
 
         # example buttons (R -> L)
         # hyprbars-button = color, size, on-click
-        hyprbars-button = rgb(ff8800), 13, 󰖭, hyprctl dispatch killactive
-        hyprbars-button = rgb(ff8800), 13, 󰖯, hyprctl dispatch fullscreen 1
-        hyprbars-button = rgb(ff8800), 13, 󰖰, hyprctl dispatch movetoworkspacesilent special
+        hyprbars-button = $blue, 13, 󰖭, hyprctl dispatch killactive
+        hyprbars-button = $blue, 13, 󰖯, hyprctl dispatch fullscreen 1
+        hyprbars-button = $blue, 13, 󰖰, hyprctl dispatch movetoworkspacesilent special
     }
 }

--- a/hypr/hyprland/colors.conf
+++ b/hypr/hyprland/colors.conf
@@ -1,10 +1,40 @@
+$background = rgba(1a1b26ff)
+$foreground = rgba(c0caf5ff)
+$black = rgba(15161Eff)
+$red = rgba(f7768eff)
+$green = rgba(9ece6aff)
+$yellow = rgba(e0af68ff)
+$blue = rgba(7aa2f7ff)
+$magenta = rgba(bb9af7ff)
+$cyan = rgba(7dcfff)
+$white = rgba(a9b1d6ff)
+$bright_black = rgba(414868ff)
+$bright_red = rgba(f7768eff)
+$bright_green = rgba(9ece6aff)
+$bright_yellow = rgba(e0af68ff)
+$bright_blue = rgba(7aa2f7ff)
+$bright_magenta = rgba(bb9af7ff)
+$bright_cyan = rgba(7dcfff)
+$bright_white = rgba(c0caf5ff)
+
 general {
-    col.active_border = rgba(ff8800FF)
-    col.inactive_border = rgba(415a77FF)
+    col.active_border = $blue
+    col.inactive_border = $bright_black
+
+    col.nogroup.border = $blue
+    col.nogroup.border.active = $blue
 }
+
+group {
+    col.border.active = $blue
+    col.border.inactive = $bright_black
+    col.border.locked.active = $blue
+    col.border.locked.inactive = $bright_black
+}
+
 
 misc {
-    background_color = rgba(0d1b2aFF)
+    background_color = $background
 }
 
-windowrulev2 = bordercolor rgba(ff8800AA) rgba(ff880077),pinned:1
+windowrulev2 = bordercolor $blue $bright_black,pinned:1

--- a/waybar/themes/style.css
+++ b/waybar/themes/style.css
@@ -1,3 +1,11 @@
+@define-color background #1a1b26;
+@define-color foreground #c0caf5;
+@define-color accent #7aa2f7;
+@define-color urgent #f7768e;
+@define-color inactive #414868;
+@define-color charging #9ece6a;
+@define-color background_transparent rgba(26, 27, 38, 0.8);
+
 * {
     border: none;
     border-radius: 10px;
@@ -8,8 +16,8 @@
 }
 
 window#waybar {
-    background: rgba(13, 27, 42, 0.8);
-    color: #c0c5ce;
+    background: @background_transparent;
+    color: @foreground;
 }
 
 #workspaces,
@@ -32,19 +40,19 @@ window#waybar {
 
 #workspaces button {
     padding: 2px 5px;
-    color: #415a77;
+    color: @inactive;
     background-color: transparent;
 }
 
 #workspaces button.focused {
-    color: #0d1b2a;
-    background-color: #ff8800;
+    color: @background;
+    background-color: @accent;
     border-radius: 10px;
 }
 
 #workspaces button.urgent {
-    color: #0d1b2a;
-    background-color: #ff5555; /* A red for urgent */
+    color: @background;
+    background-color: @urgent;
     border-radius: 10px;
 }
 
@@ -57,15 +65,15 @@ window#waybar {
 #pulseaudio,
 #custom-weather,
 #custom-power {
-    color: #c0c5ce;
+    color: @foreground;
 }
 
 #battery.charging,
 #battery.plugged {
-    color: #89b4fa; /* A light blue to indicate charging */
+    color: @charging;
 }
 
 #battery.critical:not(.charging) {
-    background-color: #ff5555;
-    color: #0d1b2a;
+    background-color: @urgent;
+    color: @background;
 }


### PR DESCRIPTION
This commit updates the color scheme for Hyprland, Waybar, and Fuzzel to match the aesthetic of the provided image.

A new color palette has been created based on the colors from the computer screens in the image. The new theme is a dark, futuristic look with blue and teal accents.

The following files have been modified:
- hypr/hyprland/colors.conf: Added a new color palette and updated existing colors.
- hypr/hyprland.conf: Updated hyprbars plugin colors.
- waybar/themes/style.css: Updated Waybar colors and added CSS variables for easier management.
- fuzzel/fuzzel.ini: Updated Fuzzel colors to match the new theme.