### PR TITLE
fix: correct hyprland and waybar configurations

### DIFF
--- a/hypr/hyprland.conf
+++ b/hypr/hyprland.conf
@@ -49,14 +49,14 @@ plugin {
         bar_precedence_over_border = true
         bar_part_of_window = true
 
-        bar_color = $background
-        col.text = $foreground
+        bar_color = rgba(1a1b26ff)
+        col.text = rgba(c0caf5ff)
 
 
         # example buttons (R -> L)
         # hyprbars-button = color, size, on-click
-        hyprbars-button = $blue, 13, 󰖭, hyprctl dispatch killactive
-        hyprbars-button = $blue, 13, 󰖯, hyprctl dispatch fullscreen 1
-        hyprbars-button = $blue, 13, 󰖰, hyprctl dispatch movetoworkspacesilent special
+        hyprbars-button = rgba(7aa2f7ff), 13, 󰖭, hyprctl dispatch killactive
+        hyprbars-button = rgba(7aa2f7ff), 13, 󰖯, hyprctl dispatch fullscreen 1
+        hyprbars-button = rgba(7aa2f7ff), 13, 󰖰, hyprctl dispatch movetoworkspacesilent special
     }
 }

--- a/hypr/hyprland/colors.conf
+++ b/hypr/hyprland/colors.conf
@@ -1,40 +1,20 @@
-$background = rgba(1a1b26ff)
-$foreground = rgba(c0caf5ff)
-$black = rgba(15161Eff)
-$red = rgba(f7768eff)
-$green = rgba(9ece6aff)
-$yellow = rgba(e0af68ff)
-$blue = rgba(7aa2f7ff)
-$magenta = rgba(bb9af7ff)
-$cyan = rgba(7dcfff)
-$white = rgba(a9b1d6ff)
-$bright_black = rgba(414868ff)
-$bright_red = rgba(f7768eff)
-$bright_green = rgba(9ece6aff)
-$bright_yellow = rgba(e0af68ff)
-$bright_blue = rgba(7aa2f7ff)
-$bright_magenta = rgba(bb9af7ff)
-$bright_cyan = rgba(7dcfff)
-$bright_white = rgba(c0caf5ff)
+# Hyprland colors
+# Defines the color scheme for the Hyprland compositor.
 
 general {
-    col.active_border = $blue
-    col.inactive_border = $bright_black
-
-    col.nogroup.border = $blue
-    col.nogroup.border.active = $blue
+    col.active_border = rgba(7aa2f7ff)
+    col.inactive_border = rgba(414868ff)
 }
 
 group {
-    col.border.active = $blue
-    col.border.inactive = $bright_black
-    col.border.locked.active = $blue
-    col.border.locked.inactive = $bright_black
+    col.border.active = rgba(7aa2f7ff)
+    col.border.inactive = rgba(414868ff)
+    col.border.locked.active = rgba(7aa2f7ff)
+    col.border.locked.inactive = rgba(414868ff)
 }
-
 
 misc {
-    background_color = $background
+    background_color = rgba(1a1b26ff)
 }
 
-windowrulev2 = bordercolor $blue $bright_black,pinned:1
+windowrulev2 = bordercolor rgba(7aa2f7ff) rgba(414868ff),pinned:1

--- a/hypr/hyprland/execs.conf
+++ b/hypr/hyprland/execs.conf
@@ -1,6 +1,6 @@
 # Bar, wallpaper
 exec-once = ~/.config/hypr/hyprland/scripts/start_geoclue_agent.sh
-exec-once = waybar -c ~/.config/waybar/config.jsonc -s ~/.config/waybar/themes/adw-dark.css &
+exec-once = waybar -c ~/.config/waybar/config.jsonc -s ~/.config/waybar/themes/style.css &
 
 # Input method
 exec-once = fcitx5

--- a/hypr/hyprland/keybinds.conf
+++ b/hypr/hyprland/keybinds.conf
@@ -13,7 +13,7 @@ bindld = Super+Shift,M, Toggle mute, exec, wpctl set-mute @DEFAULT_SINK@ toggle 
 bindl = Alt ,XF86AudioMute, exec, wpctl set-mute @DEFAULT_SOURCE@ toggle # [hidden]
 bindl = ,XF86AudioMicMute, exec, wpctl set-mute @DEFAULT_SOURCE@ toggle # [hidden]
 bindld = Super+Alt,M, Toggle mic, exec, wpctl set-mute @DEFAULT_SOURCE@ toggle # [hidden]
-bind = Ctrl+Super, R, exec, killall waybar && waybar -c ~/.config/waybar/config.jsonc -s ~/.config/waybar/themes/adw-dark.css & # Restart widgets
+bind = Ctrl+Super, R, exec, killall waybar && waybar -c ~/.config/waybar/config.jsonc -s ~/.config/waybar/themes/style.css & # Restart widgets
 
 # Apps
 bind = Super, Space, exec, zsh -ic "fuzzel"


### PR DESCRIPTION
This commit fixes the issues reported by the user:

1.  **Hyprland configuration errors:** The syntax in `hypr/hyprland/colors.conf` and `hypr/hyprland.conf` has been corrected. Color variables are no longer used, and invalid configuration options have been removed.
2.  **Waybar stylesheet:** The Waybar launch commands in `hypr/hyprland/execs.conf` and `hypr/hyprland/keybinds.conf` have been updated to use the correct stylesheet (`style.css`), so the new theme is applied correctly.