### PR TITLE
fix: correct hyprland configuration files

### DIFF
--- a/hypr/hyprland.conf
+++ b/hypr/hyprland.conf
@@ -38,25 +38,6 @@ plugin {
     }
 }
 
-# hyprbars from hypr/hyprland/colors.conf
-plugin {
-    hyprbars {
-        # Honestly idk if it works like css, but well, why not
-        bar_text_font = Rubik, Geist, AR One Sans, Reddit Sans, Inter, Roboto, Ubuntu, Noto Sans, sans-serif
-        bar_height = 30
-        bar_padding = 10
-        bar_button_padding = 5
-        bar_precedence_over_border = true
-        bar_part_of_window = true
-
-        bar_color = rgba(1a1b26ff)
-        col.text = rgba(c0caf5ff)
-
-
-        # example buttons (R -> L)
-        # hyprbars-button = color, size, on-click
-        hyprbars-button = rgba(7aa2f7ff), 13, 󰖭, hyprctl dispatch killactive
-        hyprbars-button = rgba(7aa2f7ff), 13, 󰖯, hyprctl dispatch fullscreen 1
-        hyprbars-button = rgba(7aa2f7ff), 13, 󰖰, hyprctl dispatch movetoworkspacesilent special
-    }
+misc {
+    background_color = rgba(1a1b26ff)
 }

--- a/hypr/hyprland/colors.conf
+++ b/hypr/hyprland/colors.conf
@@ -5,16 +5,3 @@ general {
     col.active_border = rgba(7aa2f7ff)
     col.inactive_border = rgba(414868ff)
 }
-
-group {
-    col.border.active = rgba(7aa2f7ff)
-    col.border.inactive = rgba(414868ff)
-    col.border.locked.active = rgba(7aa2f7ff)
-    col.border.locked.inactive = rgba(414868ff)
-}
-
-misc {
-    background_color = rgba(1a1b26ff)
-}
-
-windowrulev2 = bordercolor rgba(7aa2f7ff) rgba(414868ff),pinned:1

--- a/hypr/hyprland/rules.conf
+++ b/hypr/hyprland/rules.conf
@@ -153,4 +153,6 @@ layerrule = ignorezero, shell:bar
 layerrule = blur, shell:notifications
 layerrule = ignorealpha 0.1, shell:notifications
 
+# Set border colors for pinned windows
+windowrulev2 = bordercolor rgba(7aa2f7ff) rgba(414868ff),pinned:1
 


### PR DESCRIPTION
This commit resolves the persistent configuration errors in Hyprland by restructuring the color and rule definitions.

- `hypr/hyprland/colors.conf` has been simplified to only contain the `general` border color definitions, which was causing the main issue.
- The `background_color` has been moved to a `misc` block in `hypr/hyprland.conf`.
- The `windowrulev2` for border colors has been moved to the correct location in `hypr/hyprland/rules.conf`.
- The erroneous `hyprbars` plugin configuration has been removed.

These changes should resolve the configuration errors and correctly apply the new color scheme to Hyprland.