### PR TITLE
feat: update color scheme with more colors and highlights

### DIFF
--- a/fuzzel/fuzzel.ini
+++ b/fuzzel/fuzzel.ini
@@ -9,9 +9,9 @@ prompt=" "
 background=1a1b26ff
 text=c0caf5ff
 match=7aa2f7ff
-selection=414868ff
-selection-text=c0caf5ff
-border=7aa2f7ff
+selection=ff9e64ff
+selection-text=1a1b26ff
+border=ff9e64ff
 
 [border]
 width=2

--- a/hypr/hyprland/colors.conf
+++ b/hypr/hyprland/colors.conf
@@ -2,6 +2,6 @@
 # Defines the color scheme for the Hyprland compositor.
 
 general {
-    col.active_border = rgba(7aa2f7ff)
+    col.active_border = rgba(ff9e64ff)
     col.inactive_border = rgba(414868ff)
 }

--- a/waybar/config.jsonc
+++ b/waybar/config.jsonc
@@ -69,14 +69,14 @@
     },
   },
   "cpu": {
-    "format": "CPU {usage}%",
+    "format": "CPU <span foreground='#ff9e64'>{usage}%</span>",
     "interval": 2,
     "states": {
       "critical": 90,
     },
   },
   "memory": {
-    "format": "Mem {percentage}%",
+    "format": "Mem <span foreground='#ff9e64'>{percentage}%</span>",
     "interval": 2,
     "states": {
       "critical": 80,
@@ -88,16 +88,16 @@
       "warning": 30,
       "critical": 15,
     },
-    "format": "{capacity}% {icon}",
-    "format-charging": "{capacity}% 󰂄",
-    "format-plugged": "{capacity}% 󰚥",
+    "format": "<span foreground='#ff9e64'>{capacity}%</span> {icon}",
+    "format-charging": "<span foreground='#ff9e64'>{capacity}%</span> 󰂄",
+    "format-plugged": "<span foreground='#ff9e64'>{capacity}%</span> 󰚥",
     "format-alt": "{time} {icon}",
     // "format-good": "", // An empty format will hide the module
     // "format-full": "",
     "format-icons": ["󰂎", "󰁺", "󰁻", "󰁼", "󰁽", "󰁾", "󰁿", "󰂀", "󰂁", "󰂂", "󰁹"],
   },
   "pulseaudio": {
-    "format": "{icon} {volume}%",
+    "format": "{icon} <span foreground='#ff9e64'>{volume}%</span>",
     "tooltip": false,
     "format-muted": " Muted",
     "on-click": "pamixer -t",
@@ -116,7 +116,7 @@
   },
   "pulseaudio#microphone": {
     "format": "{format_source}",
-    "format-source": "󰍬 {volume}%",
+    "format-source": "󰍬 <span foreground='#ff9e64'>{volume}%</span>",
     "format-source-muted": "󰍭 Muted",
     "on-click": "pamixer --default-source -t",
     "on-scroll-up": "pamixer --default-source -i 5",
@@ -124,7 +124,7 @@
     "scroll-step": 5,
   },
   "network": {
-    "format-wifi": "󰤨  {signalStrength}%",
+    "format-wifi": "󰤨 <span foreground='#ff9e64'>{signalStrength}%</span>",
     "format-ethernet": "{ipaddr}/{cidr}",
     "tooltip-format": "{essid} - {ifname} via {gwaddr}",
     "format-linked": "{ifname} (No IP)",

--- a/waybar/themes/style.css
+++ b/waybar/themes/style.css
@@ -1,6 +1,9 @@
 @define-color background #1a1b26;
 @define-color foreground #c0caf5;
-@define-color accent #7aa2f7;
+@define-color highlight #ff9e64;
+@define-color accent_blue #7aa2f7;
+@define-color accent_cyan #7dcfff;
+@define-color accent_green #9ece6a;
 @define-color urgent #f7768e;
 @define-color inactive #414868;
 @define-color charging #9ece6a;
@@ -46,7 +49,7 @@ window#waybar {
 
 #workspaces button.focused {
     color: @background;
-    background-color: @accent;
+    background-color: @highlight;
     border-radius: 10px;
 }
 
@@ -68,9 +71,17 @@ window#waybar {
     color: @foreground;
 }
 
+#cpu {
+    color: @accent_cyan;
+}
+
+#memory {
+    color: @accent_green;
+}
+
 #battery.charging,
 #battery.plugged {
-    color: @charging;
+    color: @accent_green;
 }
 
 #battery.critical:not(.charging) {


### PR DESCRIPTION
This commit updates the color scheme for Hyprland, Waybar, and Fuzzel based on the user's feedback.

- The color palette has been revised to be more comprehensive, incorporating orange, cyan, and green from the provided image.
- Orange is now used as the highlight color for the active window border in Hyprland, selections in Fuzzel, and values in Waybar modules.
- The Waybar theme has been updated to use the new accent colors for different modules.
- The Waybar module format strings have been updated to use Pango markup to color the values separately from the labels.