### PR TITLE
feat: add hyprbars config and documentation

### DIFF
--- a/hypr/README.md
+++ b/hypr/README.md
@@ -1,0 +1,57 @@
+# Hyprland Configuration
+
+This directory contains the configuration for the Hyprland compositor.
+
+## Structure
+
+The configuration is split into two main directories:
+- `hyprland/`: Contains the default configuration files.
+- `custom/`: Contains user-specific overrides and custom scripts.
+
+Settings in `custom/` will override the default settings in `hyprland/`.
+
+## Plugins
+
+This configuration uses the following plugins:
+
+### hyprpm
+
+`hyprpm` is the Hyprland Plugin Manager. It is used to manage plugins. The command `hyprpm reload` is run on startup to load all enabled plugins.
+
+### hyprexpo
+
+`hyprexpo` is a workspace overview plugin that allows you to see all your workspaces at once.
+
+**Usage:**
+There is no explicit keybinding set for `hyprexpo` in this configuration. It may be triggered by a default keybinding or a mouse gesture. The configuration in `hyprland.conf` can be consulted for more details.
+
+### hyprbars
+
+`hyprbars` is a plugin that provides title bars for windows.
+
+**Configuration:**
+This plugin is configured to only show on terminal windows. It uses a blacklist approach, defined in `hypr/hyprland/rules.conf`, to disable the bar for common non-terminal applications.
+
+## Keybindings
+
+Here are some of the most important keybindings in this configuration:
+
+| Keybinding | Description |
+| --- | --- |
+| `Super + Space` | Launch application launcher (fuzzel) |
+| `Super + V` | Show clipboard history |
+| `Super + Shift + S` | Take a screen snip |
+| `Super + Q` | Close active window |
+| `Super + L` | Lock the session |
+| `Super + Return` | Launch terminal (kitty) |
+| `Super + E` | Launch file manager |
+| `Super + W` | Launch web browser |
+| `Super + C` | Launch code editor |
+| `Super + [0-9]` | Switch to workspace |
+| `Super + Alt + [0-9]` | Move window to workspace |
+| `Super + S` | Toggle special workspace (scratchpad) |
+| `Super + D` | Maximize window |
+| `Super + F` | Toggle fullscreen |
+| `Super + P` | Pin window |
+| `Super + Left/Right/Up/Down` | Move focus |
+| `Super + Shift + Left/Right/Up/Down` | Move window |

--- a/hypr/hyprland.conf
+++ b/hypr/hyprland.conf
@@ -41,3 +41,26 @@ plugin {
 misc {
     background_color = rgba(1a1b26ff)
 }
+
+# hyprbars from hypr/hyprland/colors.conf
+plugin {
+    hyprbars {
+        # Honestly idk if it works like css, but well, why not
+        bar_text_font = Rubik, Geist, AR One Sans, Reddit Sans, Inter, Roboto, Ubuntu, Noto Sans, sans-serif
+        bar_height = 30
+        bar_padding = 10
+        bar_button_padding = 5
+        bar_precedence_over_border = true
+        bar_part_of_window = true
+
+        bar_color = rgba(1a1b26ff)
+        col.text = rgba(c0caf5ff)
+
+
+        # example buttons (R -> L)
+        # hyprbars-button = color, size, on-click
+        hyprbars-button = rgba(7aa2f7ff), 13, 󰖭, hyprctl dispatch killactive
+        hyprbars-button = rgba(7aa2f7ff), 13, 󰖯, hyprctl dispatch fullscreen 1
+        hyprbars-button = rgba(7aa2f7ff), 13, 󰖰, hyprctl dispatch movetoworkspacesilent special
+    }
+}


### PR DESCRIPTION
This commit addresses the user's feedback by:

- Restoring the `hyprbars` plugin configuration to `hypr/hyprland.conf` and theming it to match the established color scheme.
- Verifying the window rules in `hypr/hyprland/rules.conf` to ensure `hyprbars` only appears on terminal windows.
- Creating a new `hypr/README.md` file with comprehensive documentation for the Hyprland configuration, including details on the structure, plugins (`hyprpm`, `hyprexpo`, `hyprbars`), and keybindings.