### PR TITLE
feat: update hyprbars and add hyprexpo keybinding

### DIFF
--- a/hypr/README.md
+++ b/hypr/README.md
@@ -23,7 +23,7 @@ This configuration uses the following plugins:
 `hyprexpo` is a workspace overview plugin that allows you to see all your workspaces at once.
 
 **Usage:**
-There is no explicit keybinding set for `hyprexpo` in this configuration. It may be triggered by a default keybinding or a mouse gesture. The configuration in `hyprland.conf` can be consulted for more details.
+The keybinding for `hyprexpo` is `CTRL+SUPER+UP_ARROW`.
 
 ### hyprbars
 
@@ -31,6 +31,8 @@ There is no explicit keybinding set for `hyprexpo` in this configuration. It may
 
 **Configuration:**
 This plugin is configured to only show on terminal windows. It uses a blacklist approach, defined in `hypr/hyprland/rules.conf`, to disable the bar for common non-terminal applications.
+
+The bar changes color to indicate whether the window is active or inactive. It has one button to close the active window.
 
 ## Keybindings
 
@@ -40,6 +42,7 @@ Here are some of the most important keybindings in this configuration:
 | --- | --- |
 | `Super + Space` | Launch application launcher (fuzzel) |
 | `Super + V` | Show clipboard history |
+| `CTRL + Super + Up` | Show workspace overview (hyprexpo) |
 | `Super + Shift + S` | Take a screen snip |
 | `Super + Q` | Close active window |
 | `Super + L` | Lock the session |

--- a/hypr/custom/keybinds.conf
+++ b/hypr/custom/keybinds.conf
@@ -13,3 +13,6 @@
 #bind = Super, Space, exec, zsh -ic "fuzzel"
 #bind = Super, V, exec, cliphist list | fuzzel -d | cliphist decode | wl-copy
 #bind = Super+Alt, W, exec, ~/.config/hypr/custom/scripts/set-wallpaper.sh
+
+##! Hyprexpo
+bind = CTRL_SUPER, Up, hyprexpo:expo, toggle

--- a/hypr/hyprland.conf
+++ b/hypr/hyprland.conf
@@ -53,14 +53,12 @@ plugin {
         bar_precedence_over_border = true
         bar_part_of_window = true
 
-        bar_color = rgba(1a1b26ff)
+        bar_color = rgba(414868ff)
         col.text = rgba(c0caf5ff)
 
 
         # example buttons (R -> L)
         # hyprbars-button = color, size, on-click
-        hyprbars-button = rgba(7aa2f7ff), 13, 󰖭, hyprctl dispatch killactive
-        hyprbars-button = rgba(7aa2f7ff), 13, 󰖯, hyprctl dispatch fullscreen 1
-        hyprbars-button = rgba(7aa2f7ff), 13, 󰖰, hyprctl dispatch movetoworkspacesilent special
+        hyprbars-button = rgba(ff9e64ff), 13, 󰖭, hyprctl dispatch killactive
     }
 }

--- a/hypr/hyprland/rules.conf
+++ b/hypr/hyprland/rules.conf
@@ -84,6 +84,7 @@ windowrulev2 = noshadow, floating:0
 # This means we cannot disable it globally and then enable it for terminals.
 # Instead, we disable it for common non-terminal applications.
 # You may need to add more rules here for your own applications.
+windowrulev2 = plugin:hyprbars:bar_color rgb(ff9e64), focus:1
 windowrulev2 = plugin:hyprbars:nobar, class:^(firefox)$
 windowrulev2 = plugin:hyprbars:nobar, class:^(Chrome)$
 windowrulev2 = plugin:hyprbars:nobar, class:^(Chromium)$


### PR DESCRIPTION
This commit implements the following changes based on user feedback:

- Adds a keybinding for `hyprexpo` to `CTRL+SUPER+UP_ARROW`.
- Updates the `hyprbars` configuration to change color for active and inactive windows using a window rule.
- Removes all buttons from `hyprbars` except for the 'kill active window' button.
- Updates the `hypr/README.md` to document these changes.