### PR TITLE
feat: update orange color and improve waybar

### DIFF
--- a/fuzzel/fuzzel.ini
+++ b/fuzzel/fuzzel.ini
@@ -9,9 +9,9 @@ prompt=" "
 background=1a1b26ff
 text=c0caf5ff
 match=7aa2f7ff
-selection=ff9e64ff
+selection=EA9D34ff
 selection-text=1a1b26ff
-border=ff9e64ff
+border=EA9D34ff
 
 [border]
 width=2

--- a/hypr/hyprland/colors.conf
+++ b/hypr/hyprland/colors.conf
@@ -2,6 +2,6 @@
 # Defines the color scheme for the Hyprland compositor.
 
 general {
-    col.active_border = rgba(ff9e64ff)
+    col.active_border = rgba(EA9D34ff)
     col.inactive_border = rgba(414868ff)
 }

--- a/waybar/config.jsonc
+++ b/waybar/config.jsonc
@@ -69,14 +69,14 @@
     },
   },
   "cpu": {
-    "format": "CPU <span foreground='#ff9e64'>{usage}%</span>",
+    "format": "CPU <span foreground='#EA9D34'>{usage}%</span>",
     "interval": 2,
     "states": {
       "critical": 90,
     },
   },
   "memory": {
-    "format": "Mem <span foreground='#ff9e64'>{percentage}%</span>",
+    "format": "Mem <span foreground='#EA9D34'>{percentage}%</span>",
     "interval": 2,
     "states": {
       "critical": 80,
@@ -88,16 +88,16 @@
       "warning": 30,
       "critical": 15,
     },
-    "format": "<span foreground='#ff9e64'>{capacity}%</span> {icon}",
-    "format-charging": "<span foreground='#ff9e64'>{capacity}%</span> 󰂄",
-    "format-plugged": "<span foreground='#ff9e64'>{capacity}%</span> 󰚥",
+    "format": "<span foreground='#EA9D34'>{capacity}%</span> {icon}",
+    "format-charging": "<span foreground='#EA9D34'>{capacity}%</span> 󰂄",
+    "format-plugged": "<span foreground='#EA9D34'>{capacity}%</span> 󰚥",
     "format-alt": "{time} {icon}",
     // "format-good": "", // An empty format will hide the module
     // "format-full": "",
     "format-icons": ["󰂎", "󰁺", "󰁻", "󰁼", "󰁽", "󰁾", "󰁿", "󰂀", "󰂁", "󰂂", "󰁹"],
   },
   "pulseaudio": {
-    "format": "{icon} <span foreground='#ff9e64'>{volume}%</span>",
+    "format": "{icon} <span foreground='#EA9D34'>{volume}%</span>",
     "tooltip": false,
     "format-muted": " Muted",
     "on-click": "pamixer -t",
@@ -116,7 +116,7 @@
   },
   "pulseaudio#microphone": {
     "format": "{format_source}",
-    "format-source": "󰍬 <span foreground='#ff9e64'>{volume}%</span>",
+    "format-source": "󰍬 <span foreground='#EA9D34'>{volume}%</span>",
     "format-source-muted": "󰍭 Muted",
     "on-click": "pamixer --default-source -t",
     "on-scroll-up": "pamixer --default-source -i 5",
@@ -124,7 +124,7 @@
     "scroll-step": 5,
   },
   "network": {
-    "format-wifi": "󰤨 <span foreground='#ff9e64'>{signalStrength}%</span>",
+    "format-wifi": "󰤨 <span foreground='#EA9D34'>{signalStrength}%</span>",
     "format-ethernet": "{ipaddr}/{cidr}",
     "tooltip-format": "{essid} - {ifname} via {gwaddr}",
     "format-linked": "{ifname} (No IP)",

--- a/waybar/themes/style.css
+++ b/waybar/themes/style.css
@@ -1,6 +1,6 @@
 @define-color background #1a1b26;
 @define-color foreground #c0caf5;
-@define-color highlight #ff9e64;
+@define-color highlight #EA9D34;
 @define-color accent_blue #7aa2f7;
 @define-color accent_cyan #7dcfff;
 @define-color accent_green #9ece6a;
@@ -33,8 +33,8 @@ window#waybar {
 #pulseaudio,
 #custom-weather,
 #custom-power {
-    padding: 2px 10px;
-    margin: 8px 4px;
+    padding: 0px 5px;
+    margin: 4px 2px;
 }
 
 #workspaces {
@@ -48,7 +48,7 @@ window#waybar {
 }
 
 #workspaces button.focused {
-    color: @background;
+    color: #1a1b26;
     background-color: @highlight;
     border-radius: 10px;
 }


### PR DESCRIPTION
- Updates the orange color to #EA9D34 across hyprland, fuzzel, and waybar configurations.
- Reduces the size of the waybar by adjusting padding and margins.
- Improves the readability of the active workspace indicator on the waybar.