### PR TITLE
feat: update foot config and document theme

### DIFF
--- a/foot/foot.ini
+++ b/foot/foot.ini
@@ -9,7 +9,7 @@
 # locked-title=no
 
 [main]
-font=Adwaita Mono:size=12
+font=iosevka nerd font:size=16
 # letter-spacing=0
 # line-height=120%
 # initial-window-size-pixels=700x500
@@ -22,25 +22,25 @@ lines=10000
 
 [colors]
 alpha=0.9
-background=0d1b2a
-foreground=c0c5ce
+background=1a1b26
+foreground=c0caf5
 
 ## Normal
-regular0=1e222a  # black
-regular1=ff5555  # red
-regular2=50fa7b  # green
-regular3=f1fa8c  # yellow
-regular4=bd93f9  # blue
+regular0=1a1b26  # black
+regular1=f7768e  # red
+regular2=9ece6a  # green
+regular3=EA9D34  # yellow
+regular4=7aa2f7  # blue
 regular5=ff79c6  # magenta
-regular6=8be9fd  # cyan
-regular7=f8f8f2  # white
+regular6=7dcfff  # cyan
+regular7=c0caf5  # white
 
 ## Bright
-bright0=6272a4   # black
-bright1=ff6e6e   # red
-bright2=69ff94   # green
-bright3=ffffa5   # yellow
-bright4=d6acff   # blue
+bright0=414868   # black
+bright1=f7768e   # red
+bright2=9ece6a   # green
+bright3=EA9D34   # yellow
+bright4=7aa2f7   # blue
 bright5=ff92df   # magenta
 bright6=a4ffff   # cyan
 bright7=ffffff   # white

--- a/hypr/README.md
+++ b/hypr/README.md
@@ -58,3 +58,19 @@ Here are some of the most important keybindings in this configuration:
 | `Super + P` | Pin window |
 | `Super + Left/Right/Up/Down` | Move focus |
 | `Super + Shift + Left/Right/Up/Down` | Move window |
+
+## Theme
+
+This configuration uses a custom theme based on the Tokyo Night color palette.
+
+| Name      | Hex       | RGB             |
+| --------- | --------- | --------------- |
+| Orange    | `#EA9D34` | `234, 157, 52`  |
+| Background| `#1a1b26` | `26, 27, 38`    |
+| Foreground| `#c0caf5` | `192, 202, 245` |
+| Inactive  | `#414868` | `65, 72, 104`   |
+| Blue      | `#7aa2f7` | `122, 162, 247` |
+| Cyan      | `#7dcfff` | `125, 207, 255` |
+| Green     | `#9ece6a` | `158, 206, 106` |
+| Red/Urgent| `#f7768e` | `247, 118, 142` |
+| Magenta   | `#ff79c6` | `255, 121, 198` |


### PR DESCRIPTION
- Updates the foot terminal configuration to use the same color palette as the rest of the theme.
- Changes the font in the foot terminal to "iosevka nerd font" at size 16 for better readability on HiDPI displays.
- Adds a "Theme" section to the `hypr/README.md` file to document the color palette, including names, hex codes, and RGB values.