### PR TITLE
fix: update all instances of orange color

### DIFF
--- a/hypr/hyprland.conf
+++ b/hypr/hyprland.conf
@@ -59,6 +59,6 @@ plugin {
 
         # example buttons (R -> L)
         # hyprbars-button = color, size, on-click
-        hyprbars-button = rgba(ff9e64ff), 13, 󰖭, hyprctl dispatch killactive
+        hyprbars-button = rgba(EA9D34ff), 13, 󰖭, hyprctl dispatch killactive
     }
 }

--- a/hypr/hyprland/rules.conf
+++ b/hypr/hyprland/rules.conf
@@ -84,7 +84,7 @@ windowrulev2 = noshadow, floating:0
 # This means we cannot disable it globally and then enable it for terminals.
 # Instead, we disable it for common non-terminal applications.
 # You may need to add more rules here for your own applications.
-windowrulev2 = plugin:hyprbars:bar_color rgb(ff9e64), focus:1
+windowrulev2 = plugin:hyprbars:bar_color rgb(EA9D34), focus:1
 windowrulev2 = plugin:hyprbars:nobar, class:^(firefox)$
 windowrulev2 = plugin:hyprbars:nobar, class:^(Chrome)$
 windowrulev2 = plugin:hyprbars:nobar, class:^(Chromium)$


### PR DESCRIPTION
This commit fixes an issue where the old orange color was still present in some configuration files.

- Updates `hypr/hyprland.conf` and `hypr/hyprland/rules.conf` to use the new orange color (`#EA9D34`).