### PR TITLE
feat: refine theme and enhance foot config

### DIFF
--- a/foot/foot.ini
+++ b/foot/foot.ini
@@ -10,6 +10,7 @@
 
 [main]
 font=iosevka nerd font:size=16
+dpi-aware=yes
 # letter-spacing=0
 # line-height=120%
 # initial-window-size-pixels=700x500
@@ -24,6 +25,7 @@ lines=10000
 alpha=0.9
 background=1a1b26
 foreground=c0caf5
+bold-text-in-bright=yes
 
 ## Normal
 regular0=1a1b26  # black
@@ -59,3 +61,6 @@ scrollback-down-page=Shift+Page_Down
 clipboard-paste=Control+Shift+v
 clipboard-copy=Control+Shift+c
 primary-paste=Shift+Insert
+font-increase=Control+plus
+font-decrease=Control+minus
+font-reset=Control+0

--- a/hypr/hyprland.conf
+++ b/hypr/hyprland.conf
@@ -59,6 +59,6 @@ plugin {
 
         # example buttons (R -> L)
         # hyprbars-button = color, size, on-click
-        hyprbars-button = rgba(EA9D34ff), 13, 󰖭, hyprctl dispatch killactive
+        hyprbars-button = rgba(7dcfffff), 13, 󰖭, hyprctl dispatch killactive
     }
 }

--- a/hypr/hyprland/rules.conf
+++ b/hypr/hyprland/rules.conf
@@ -84,7 +84,7 @@ windowrulev2 = noshadow, floating:0
 # This means we cannot disable it globally and then enable it for terminals.
 # Instead, we disable it for common non-terminal applications.
 # You may need to add more rules here for your own applications.
-windowrulev2 = plugin:hyprbars:bar_color rgb(EA9D34), focus:1
+windowrulev2 = plugin:hyprbars:bar_color rgb(7dcfff), focus:1
 windowrulev2 = plugin:hyprbars:nobar, class:^(firefox)$
 windowrulev2 = plugin:hyprbars:nobar, class:^(Chrome)$
 windowrulev2 = plugin:hyprbars:nobar, class:^(Chromium)$


### PR DESCRIPTION
- Updates the Hyprbar color scheme to use blues instead of orange, with a light blue for active windows and a dark blue for inactive windows.
- Enhances the foot terminal configuration for better HiDPI support and usability by:
  - Enabling DPI awareness.
  - Making bold text in bright colors.
  - Adding keybindings for font size adjustment.