### PR TITLE
fix: ensure consistent color theme in foot terminal

### DIFF
--- a/foot/foot.ini
+++ b/foot/foot.ini
@@ -43,8 +43,8 @@ bright1=f7768e   # red
 bright2=9ece6a   # green
 bright3=EA9D34   # yellow
 bright4=7aa2f7   # blue
-bright5=ff92df   # magenta
-bright6=a4ffff   # cyan
+bright5=ff79c6   # magenta
+bright6=7dcfff   # cyan
 bright7=ffffff   # white
 
 [cursor]


### PR DESCRIPTION
This commit resolves the theme inconsistency in the foot terminal configuration by aligning its color palette, particularly the 'bright' color variants, with the established theme used across hyprland, fuzzel, and waybar.

This ensures a uniform and consistent visual experience as requested.