### PR TITLE
fix: apply hyprland visual and behavior tweaks

### DIFF
--- a/hypr/hyprland/general.conf
+++ b/hypr/hyprland/general.conf
@@ -19,8 +19,8 @@ gestures {
 
 general {
     # Gaps and border
-    gaps_in = 4
-    gaps_out = 5
+    gaps_in = 8
+    gaps_out = 10
     gaps_workspaces = 50
     
     border_size = 3
@@ -45,7 +45,7 @@ dwindle {
 }
 
 decoration {
-    rounding = 18
+    rounding = 0
     
     blur {
         enabled = true
@@ -66,10 +66,10 @@ decoration {
     shadow {
         enabled = true
         ignore_window = true
-        range = 30
+        range = 32
         offset = 0 2
-        render_power = 4
-        color = rgba(00000010)
+        render_power = 5
+        color = rgba(00000055)
     }
     
     # Dim
@@ -114,7 +114,7 @@ input {
     repeat_delay = 250
     repeat_rate = 35
     
-    follow_mouse = 1
+    follow_mouse = 0
     off_window_axis_events = 2
 
     touchpad {


### PR DESCRIPTION
This commit addresses user feedback regarding the visual and behavioral settings in Hyprland.

- Sets window corner rounding to 0 for square corners.
- Increases inner and outer window gaps for more spacing.
- Enhances drop shadows to be more prominent.
- Disables the 'focus follows mouse' behavior.