### PR TITLE
fix: change active hyprbar color to blue

### DIFF
--- a/hypr/hyprland.conf
+++ b/hypr/hyprland.conf
@@ -59,6 +59,6 @@ plugin {
 
         # example buttons (R -> L)
         # hyprbars-button = color, size, on-click
-        hyprbars-button = rgba(1c9999ff), 13, 󰖭, hyprctl dispatch killactive
+        hyprbars-button = rgba(42718aff), 13, 󰖭, hyprctl dispatch killactive
     }
 }

--- a/hypr/hyprland/rules.conf
+++ b/hypr/hyprland/rules.conf
@@ -84,7 +84,7 @@ windowrulev2 = noshadow, floating:0
 # This means we cannot disable it globally and then enable it for terminals.
 # Instead, we disable it for common non-terminal applications.
 # You may need to add more rules here for your own applications.
-windowrulev2 = plugin:hyprbars:bar_color rgb(1c9999), focus:1
+windowrulev2 = plugin:hyprbars:bar_color rgb(42718a), focus:1
 windowrulev2 = plugin:hyprbars:nobar, class:^(firefox)$
 windowrulev2 = plugin:hyprbars:nobar, class:^(Chrome)$
 windowrulev2 = plugin:hyprbars:nobar, class:^(Chromium)$


### PR DESCRIPTION
This commit changes the color of the active hyprbar and its button from Cyan to Blue (`#42718a`) based on user feedback that the previous color was too bright.