### PR TITLE
feat(waybar): add update checker and fix weather widget

### DIFF
--- a/waybar/config.jsonc
+++ b/waybar/config.jsonc
@@ -13,8 +13,16 @@
     "network",
     "pulseaudio",
     "custom/weather",
+    "custom/updates",
     "custom/power",
   ],
+  "custom/updates": {
+    "exec": "~/.config/waybar/scripts/update-checker.sh",
+    "return-type": "json",
+    "format": "󰏔 {text}",
+    "interval": 3600,
+    "tooltip": true
+  },
   "custom/power": {
     "format": "",
     "on-click": "~/.config/waybar/scripts/power.sh",
@@ -22,8 +30,9 @@
   },
   "custom/weather": {
     "exec": "~/.config/waybar/scripts/weather.sh",
+    "return-type": "json",
     "interval": 1800,
-    "tooltip": true,
+    "tooltip": false,
     "format": "{text}"
   },
   "hyprland/workspaces": {

--- a/waybar/scripts/update-checker.sh
+++ b/waybar/scripts/update-checker.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+
+# Get the OS ID from /etc/os-release
+OS_ID=$(grep -oP '(?<=^ID=).+' /etc/os-release | tr -d '"')
+
+# Function to get updates for Arch Linux
+get_arch_updates() {
+    UPDATES=$(checkupdates)
+    if [ -n "$UPDATES" ]; then
+        COUNT=$(echo "$UPDATES" | wc -l)
+        TOOLTIP=$(echo "$UPDATES")
+        echo "{\"text\": \"$COUNT\", \"tooltip\": \"$TOOLTIP\"}"
+    else
+        echo "{}"
+    fi
+}
+
+# Function to get updates for Fedora
+get_fedora_updates() {
+    UPDATES=$(dnf check-update -q | grep -v '^Obsoleting ')
+    if [ -n "$UPDATES" ]; then
+        COUNT=$(echo "$UPDATES" | wc -l)
+        TOOLTIP=$(echo "$UPDATES" | awk '{print $1}')
+        echo "{\"text\": \"$COUNT\", \"tooltip\": \"$TOOLTIP\"}"
+    else
+        echo "{}"
+    fi
+}
+
+# Function to get updates for Debian/Kali
+get_debian_updates() {
+    # It's important to run apt update in the background periodically
+    # This script will not run apt update to avoid sudo prompts
+    UPDATES=$(apt list --upgradable 2>/dev/null | tail -n +2)
+    if [ -n "$UPDATES" ]; then
+        COUNT=$(echo "$UPDATES" | wc -l)
+        TOOLTIP=$(echo "$UPDATES" | awk -F/ '{print $1}')
+        echo "{\"text\": \"$COUNT\", \"tooltip\": \"$TOOLTIP\"}"
+    else
+        echo "{}"
+    fi
+}
+
+case "$OS_ID" in
+    "arch")
+        get_arch_updates
+        ;;
+    "fedora")
+        get_fedora_updates
+        ;;
+    "debian" | "kali")
+        get_debian_updates
+        ;;
+    *)
+        echo "{}" # Don't show anything if the OS is not supported
+        ;;
+esac


### PR DESCRIPTION
This commit introduces a new script to check for package updates on Arch, Fedora, Debian, and Kali Linux. The script is integrated into Waybar to display the number of available updates.

Additionally, this commit fixes an issue with the weather widget where the raw JSON was being displayed instead of the formatted text. The tooltip for the weather widget has also been disabled as requested.