### PR TITLE
fix(waybar): ensure scripts output single-line JSON

### DIFF
--- a/waybar/scripts/weather.sh
+++ b/waybar/scripts/weather.sh
@@ -42,4 +42,4 @@ esac
 
 TEXT_CONTENT="$ICON $WEATHER_TEMP°C"
 
-jq -n --arg text "$TEXT_CONTENT" --arg tooltip "$WEATHER_DESC" '{"text": $text, "tooltip": $tooltip}'
+jq -c -n --arg text "$TEXT_CONTENT" --arg tooltip "$WEATHER_DESC" '{"text": $text, "tooltip": $tooltip}'


### PR DESCRIPTION
This commit fixes a bug where the `weather.sh` and `update-checker.sh` scripts were outputting multi-line JSON, causing parsing errors in Waybar.

The scripts have been updated to use `jq -c` to produce compact, single-line JSON output. The `update-checker.sh` script has also been improved to use `jq` for safer JSON construction.