### PR TITLE
fix(waybar): add styling for tooltips

### DIFF
--- a/waybar/themes/style.css
+++ b/waybar/themes/style.css
@@ -88,3 +88,14 @@ window#waybar {
     background-color: @urgent;
     color: @background;
 }
+
+tooltip {
+    background-color: @background;
+    border: 1px solid @highlight;
+    border-radius: 5px;
+    padding: 5px;
+}
+
+tooltip label {
+    color: @foreground;
+}


### PR DESCRIPTION
This commit adds CSS rules to `waybar/themes/style.css` to style the tooltips. The tooltips were previously unstyled and did not match the look and feel of the Waybar.

The new styles make the tooltips consistent with the rest of the bar, using the same background and foreground colors, and adding a border and padding.