### PR TITLE
fix(fuzzel): Ensure all applications are launchable in Hyprland

### DIFF
--- a/hypr/hyprland/keybinds.conf
+++ b/hypr/hyprland/keybinds.conf
@@ -11,7 +11,7 @@ bindld = Super+Alt,M, Toggle mic, exec, wpctl set-mute @DEFAULT_SOURCE@ toggle
 bind = Ctrl+Super, R, exec, killall waybar && waybar -c ~/.config/waybar/config.jsonc -s ~/.config/waybar/themes/style.css & # Restart widgets
 
 # Apps
-bind = Super, Space, exec, zsh -ic "fuzzel"
+bind = Super, Space, exec, ~/.config/hypr/hyprland/scripts/fuzzel-apps.sh
 # bind = Super, V, exec, cliphist list | fuzzel -d | cliphist decode | wl-copy
 bind = Super+Alt, W, exec, ~/.config/hypr/custom/scripts/set-wallpaper.sh
 

--- a/hypr/hyprland/scripts/fuzzel-apps.sh
+++ b/hypr/hyprland/scripts/fuzzel-apps.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# Get a list of all .desktop files
+files=$(find /usr/share/applications ~/.local/share/applications -name "*.desktop")
+
+# Parse each .desktop file to extract the name and exec command
+apps=""
+for file in $files; do
+    name=$(grep -E "^Name=" "$file" | cut -d'=' -f2)
+    exec=$(grep -E "^Exec=" "$file" | cut -d'=' -f2 | sed 's/ %.//')
+    nodisplay=$(grep -E "^NoDisplay=" "$file" | cut -d'=' -f2)
+
+    # Skip if NoDisplay is true or if there's no exec command
+    if [ "$nodisplay" = "true" ] || [ -z "$exec" ]; then
+        continue
+    fi
+
+    apps+="$name\t$exec\n"
+done
+
+# Pipe the list to fuzzel and execute the selected command
+selected=$(echo -e "$apps" | fuzzel --dmenu | awk -F'\t' '{print $2}')
+if [ -n "$selected" ]; then
+    eval "$selected" &
+fi


### PR DESCRIPTION
Fuzzel was not launching all applications when run directly from the Hyprland configuration. This was likely due to issues with the shell environment when using `zsh -ic "fuzzel"`.

This change replaces the direct call to Fuzzel with a script that generates a list of applications from `.desktop` files and pipes them to Fuzzel in dmenu mode. This ensures that all applications are found and can be launched correctly.

The following changes were made:
- Modified `hypr/hyprland/keybinds.conf` to execute the new script.
- Created `hypr/hyprland/scripts/fuzzel-apps.sh` to generate the application list.
- Made the new script executable.