### PR TITLE
fix: Correct waybar updates visibility and add hover effects

### DIFF
--- a/waybar/config.jsonc
+++ b/waybar/config.jsonc
@@ -21,8 +21,7 @@
     "tooltip": true,
     "tooltip-format": "{tooltip}",
     "interval": 3600,
-    "on-click": "kitty -e sudo dnf upgrade -y",
-    "escape": true
+    "on-click": "kitty -e sudo dnf upgrade -y"
   },
   "custom/power": {
     "format": "",

--- a/waybar/themes/style.css
+++ b/waybar/themes/style.css
@@ -117,3 +117,13 @@ tooltip label {
 #custom-updates.updates {
   color: @urgent;
 }
+
+#cpu:hover,
+#memory:hover,
+#pulseaudio:hover,
+#custom-weather:hover,
+#custom-updates:hover,
+#custom-power:hover {
+  background-color: @inactive;
+  border-radius: 10px;
+}


### PR DESCRIPTION
This commit addresses two issues with the Waybar configuration:

1.  The `custom/updates` widget was not showing up when updates were available. This was caused by the `escape: true` property, which has been removed.

2.  Added a hover effect to several widgets (`cpu`, `memory`, `pulseaudio`, `custom-weather`, `custom-updates`, `custom-power`) to provide better visual feedback.

This commit builds upon the previous changes to `fuzzel-apps.py` and the Waybar configuration.