### PR TITLE
Fix(fuzzel-apps): Ensure sane PATH when running from Hyprland

### DIFF
--- a/hypr/hyprland/scripts/fuzzel-apps.py
+++ b/hypr/hyprland/scripts/fuzzel-apps.py
@@ -168,6 +168,28 @@ def main():
     This script finds all .desktop files, parses them, caches the results,
     and then uses fuzzel to provide a searchable application launcher.
     """
+    # Ensure a sane PATH environment variable to find executables, especially when
+    # run from a minimal environment like the hyprland exec dispatcher.
+    home_dir = Path.home()
+    sane_paths = [
+        str(home_dir / ".local/bin"),
+        "/usr/local/sbin",
+        "/usr/local/bin",
+        "/usr/sbin",
+        "/usr/bin",
+        "/sbin",
+        "/bin",
+    ]
+    original_path = os.environ.get("PATH", "")
+
+    # Combine sane paths with the original path, avoiding duplicates
+    path_parts = sane_paths
+    if original_path:
+        path_parts.extend(original_path.split(os.pathsep))
+
+    unique_paths = list(dict.fromkeys(path_parts))
+    os.environ["PATH"] = os.pathsep.join(unique_paths)
+
     global DEBUG
     parser = argparse.ArgumentParser()
     parser.add_argument("--debug", action="store_true", help="Enable debug mode")


### PR DESCRIPTION
The script fails to launch applications from Hyprland keybindings due to a minimal PATH environment. This change ensures a sane PATH is constructed at runtime.

When launched via a keybinding, the script doesn't inherit the user's full shell environment, leading to a minimal `PATH`. This causes `shutil.which()` and `subprocess.Popen()` to fail when trying to locate application executables.

This patch modifies the script to programmatically define a comprehensive `PATH` at startup, including standard system and user binary directories. This makes the script's execution environment consistent and allows it to reliably find and launch applications, whether run from a terminal or a keybinding.