### PR TITLE
feat: Enhance fuzzel launcher and Neovim quit behavior

### DIFF
--- a/hypr/hyprland/scripts/fuzzel-apps.sh
+++ b/hypr/hyprland/scripts/fuzzel-apps.sh
@@ -3,7 +3,7 @@
 # A robust application launcher for Fuzzel with JSON caching,
 # custom overrides, usage frequency sorting, and icon support.
 #
-# DEPENDENCIES: jq, find, stat, awk
+# DEPENDENCIES: jq, find, stat, awk, printf
 #
 
 # --- Configuration & Paths ---
@@ -22,151 +22,111 @@ mkdir -p "$CONFIG_DIR" "$CACHE_DIR" "$HISTORY_DIR"
 [ ! -s "$HISTORY_FILE" ] && echo "{}" > "$HISTORY_FILE"
 
 # --- Application Directories ---
-# Build a list of directories to search for .desktop files
 APP_DIRS=()
-# User-specific directories
 [ -d "$HOME/.local/share/applications" ] && APP_DIRS+=("$HOME/.local/share/applications")
 [ -d "$HOME/.local/share/flatpak/exports/share/applications" ] && APP_DIRS+=("$HOME/.local/share/flatpak/exports/share/applications")
-
-# System-wide directories from XDG_DATA_DIRS
 IFS=':' read -r -a xdg_data_dirs <<< "${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
 for dir in "${xdg_data_dirs[@]}"; do
     [ -d "$dir/applications" ] && APP_DIRS+=("$dir/applications")
     [ -d "$dir/flatpak/exports/share/applications" ] && APP_DIRS+=("$dir/flatpak/exports/share/applications")
 done
-# System-wide flatpak directory
 [ -d "/var/lib/flatpak/exports/share/applications" ] && APP_DIRS+=("/var/lib/flatpak/exports/share/applications")
 
 # --- Cache Management ---
-# Check if the cache is stale and needs regeneration
 is_cache_stale() {
     if [ ! -f "$CACHE_FILE" ]; then return 0; fi
-
     local cache_mtime
     cache_mtime=$(stat -c %Y "$CACHE_FILE")
-
-    # Check if overrides file is newer
-    if [ -f "$OVERRIDES_FILE" ] && [ "$(stat -c %Y "$OVERRIDES_FILE")" -gt "$cache_mtime" ]; then
-        return 0
-    fi
-
-    # Check if this script is newer
-    if [ "$0" -nt "$CACHE_FILE" ]; then
-        return 0
-    fi
-
-    # Check if any application directory is newer
+    [ -f "$OVERRIDES_FILE" ] && [ "$(stat -c %Y "$OVERRIDES_FILE")" -gt "$cache_mtime" ] && return 0
+    [ "$0" -nt "$CACHE_FILE" ] && return 0
     for dir in "${APP_DIRS[@]}"; do
-        # Some dirs in XDG_DATA_DIRS might not exist, so check
-        if [ -d "$dir" ] && [ "$(stat -c %Y "$dir")" -gt "$cache_mtime" ]; then
-            return 0
-        fi
+        [ -d "$dir" ] && [ "$(stat -c %Y "$dir")" -gt "$cache_mtime" ] && return 0
     done
-
-    return 1 # Cache is fresh
+    return 1
 }
 
-# Generate the application cache
 generate_cache() {
-    # 1. Scan all .desktop files and convert to a stream of JSON objects
     local scanned_apps
     scanned_apps=$(
         find "${APP_DIRS[@]}" -mindepth 1 -type f -name "*.desktop" -print0 2>/dev/null |
         while IFS= read -r -d '' desktop_file; do
-            # Use awk to parse the desktop file, extracting relevant fields.
-            # It handles multiple Name entries (e.g., Name[en_US]) by taking the first one.
             awk -F'=' '
-            BEGIN {
-                name=""; exec_cmd=""; icon=""; terminal="false"; nodisplay="false";
-            }
-            /^\[Desktop Entry\]/ { in_entry=1 }
-            in_entry && /^Name/ { if(!name) name=substr($0, index($0, "=") + 1) }
-            in_entry && /^Exec/ { if(!exec_cmd) exec_cmd=substr($0, index($0, "=") + 1) }
-            in_entry && /^Icon/ { if(!icon) icon=substr($0, index($0, "=") + 1) }
-            in_entry && /^Terminal/ { terminal=($2=="true" ? "true" : "false") }
-            in_entry && /^NoDisplay/ { nodisplay=($2=="true" ? "true" : "false") }
-            END {
-                if (name && exec_cmd && nodisplay != "true") {
-                    # Clean Exec command: remove field codes like %f, %U, etc.
-                    # A simple approach that works for most cases.
-                    gsub(/%[a-zA-Z]/, "", exec_cmd);
-                    # Escape backslashes and double quotes for JSON
-                    gsub(/\\/, "\\\\", name); gsub(/"/, "\\\"", name);
-                    gsub(/\\/, "\\\\", exec_cmd); gsub(/"/, "\\\"", exec_cmd);
-                    gsub(/\\/, "\\\\", icon); gsub(/"/, "\\\"", icon);
-                    # Set default icon if not present
-                    if (!icon) icon="application-x-executable";
-                    # Output as a JSON object
-                    printf "{\"name\":\"%s\",\"exec\":\"%s\",\"terminal\":%s,\"icon\":\"%s\"}\n", name, exec_cmd, terminal, icon
+                BEGIN {
+                    generic_name=""; en_name=""; en_us_name="";
+                    exec_cmd=""; icon=""; terminal="false"; nodisplay="false";
                 }
-            }
+                /\[Desktop Entry\]/ { in_entry=1 }
+                in_entry {
+                    val = substr($0, index($0, "=") + 1);
+                    if ($1 == "Name")        { generic_name = val }
+                    if ($1 == "Name[en]")    { en_name = val }
+                    if ($1 == "Name[en_US]") { en_us_name = val }
+                    if ($1 == "Exec" && !exec_cmd)      { exec_cmd = val }
+                    if ($1 == "Icon" && !icon)          { icon = val }
+                    if ($1 == "Terminal")               { terminal = (val == "true" ? "true" : "false") }
+                    if ($1 == "NoDisplay")              { nodisplay = (val == "true" ? "true" : "false") }
+                }
+                END {
+                    name = en_us_name ? en_us_name : (en_name ? en_name : generic_name);
+                    if (name && exec_cmd && nodisplay != "true") {
+                        gsub(/%[a-zA-Z]/, "", exec_cmd);
+                        gsub(/\\/, "\\\\", name); gsub(/"/, "\\\"", name);
+                        gsub(/\\/, "\\\\", exec_cmd); gsub(/"/, "\\\"", exec_cmd);
+                        gsub(/\\/, "\\\\", icon); gsub(/"/, "\\\"", icon);
+                        if (!icon) icon="application-x-executable";
+                        printf "{\"name\":\"%s\",\"exec\":\"%s\",\"terminal\":%s,\"icon\":\"%s\"}\n", name, exec_cmd, terminal, icon
+                    }
+                }
             ' "$desktop_file"
-        done | jq -s '.' # Aggregate all JSON objects into a single array
+        done | jq -s '.'
     )
-    # Ensure scanned_apps is a valid JSON array, even if find returns nothing.
     scanned_apps=${scanned_apps:-'[]'}
 
-    # 2. Load overrides from the specified file
     local overrides_apps
     if [ -f "$OVERRIDES_FILE" ]; then
-        # This handles the simple "Name": "exec" format
         overrides_apps=$(jq 'to_entries | map({name: .key, exec: .value, terminal: false, icon: "application-x-executable"})' "$OVERRIDES_FILE" 2>/dev/null)
     fi
-    # Ensure overrides_apps is a valid JSON array
     overrides_apps=${overrides_apps:-'[]'}
 
-    # 3. Merge scanned apps and overrides, with overrides taking precedence.
-    #    'unique_by(.name)' keeps the first occurrence, so we put overrides first.
     jq -n --argjson overrides "$overrides_apps" --argjson scanned "$scanned_apps" \
         '($overrides + $scanned) | unique_by(.name)' > "$CACHE_FILE"
 }
 
 # --- Main Logic ---
-# Regenerate cache if it's stale
 if is_cache_stale; then
     generate_cache
 fi
 
-# Exit if cache is still empty (e.g., no .desktop files found)
 if [ ! -s "$CACHE_FILE" ]; then
     echo "Application cache is empty. No applications found." >&2
     exit 1
 fi
 
-# Merge app list with usage history for sorting
-# The subshell <(jq . "$HISTORY_FILE") handles cases where history file is invalid JSON
 apps_with_history=$(
-    jq -s '
-        .[0] as $history | .[1] as $apps |
-        $apps | map(. + {count: ($history[.name] // 0)})
-    ' <(jq . "$HISTORY_FILE" 2>/dev/null || echo "{}") "$CACHE_FILE"
+    jq -s '.[0] as $history | .[1] as $apps | $apps | map(. + {count: ($history[.name] // 0)})' \
+    <(jq . "$HISTORY_FILE" 2>/dev/null || echo "{}") "$CACHE_FILE"
 )
 
-# Sort applications by usage count (descending) and then by name (ascending)
 sorted_apps=$(echo "$apps_with_history" | jq 'sort_by(-.count, .name)')
 
-# Format for Fuzzel: text\0icon\x1f<icon_name>
-# Use a default icon if the icon value is null or empty
-fuzzel_input=$(echo "$sorted_apps" | jq -r '.[] | .name + "\u0000icon\u001f" + (.icon // "application-x-executable")')
+# --- Fuzzel Execution ---
+# Use jq to create a printf-compatible format string.
+# Each line will be 'AppName\0icon\x1fIconName\n'
+# Then pipe to printf "%b" to correctly interpret the backslash escapes.
+fuzzel_input_template=$(echo "$sorted_apps" | jq -r '.[] | .name + "\\0icon\\x1f" + (.icon // "application-x-executable") + "\\n"')
 
-# Run Fuzzel
-# The `if ...; then ...; fi` construct avoids issues with `set -e`
 chosen_app_name=""
-if ! chosen_app_name=$(echo -e "$fuzzel_input" | fuzzel --dmenu --log-level=none); then
-    # Exit if fuzzel was closed (e.g., by pressing Esc, which gives exit code 1)
+if ! chosen_app_name=$(printf "%b" "$fuzzel_input_template" | fuzzel --dmenu --log-level=none); then
     exit 0
 fi
 
-# Exit if Fuzzel returned an empty selection
 if [ -z "$chosen_app_name" ]; then
     exit 0
 fi
 
 # --- Application Launching ---
-# Find the chosen application's details from the sorted list
 chosen_app_details=$(echo "$sorted_apps" | jq --arg name "$chosen_app_name" '.[] | select(.name == $name)')
 
-# Exit if the chosen app is not found in our list (should not happen)
 if [ -z "$chosen_app_details" ]; then
     echo "Error: Could not find details for '$chosen_app_name'" >&2
     exit 1
@@ -175,14 +135,9 @@ fi
 exec_cmd=$(echo "$chosen_app_details" | jq -r '.exec')
 is_terminal=$(echo "$chosen_app_details" | jq -r '.terminal')
 
-# Update usage history
-# Use a temporary file for atomic write to avoid corruption
 tmp_history_file=$(mktemp)
 jq --arg name "$chosen_app_name" '.[$name] = (.[$name] // 0) + 1' <(jq . "$HISTORY_FILE" 2>/dev/null || echo "{}") > "$tmp_history_file" && mv "$tmp_history_file" "$HISTORY_FILE"
 
-
-# Launch the application
-# Use `hyprctl dispatch exec` for better integration with Hyprland
 if [ "$is_terminal" = "true" ]; then
     hyprctl dispatch exec -- "$TERMCMD" sh -c "$exec_cmd"
 else


### PR DESCRIPTION
This commit includes two main feature enhancements and corrections based on user feedback.

feat(fuzzel): Enhance fuzzel-apps.sh and update keybinding

This introduces a major overhaul of the `fuzzel-apps.sh` script to improve its functionality and robustness. It addresses feedback on the previous version.

Key features and improvements:
- **Correct Localization**: The script now correctly parses `.desktop` files to prioritize English names (`Name[en_US]`, `Name[en]`) over others.
- **Fixed Icon Display**: Switched to using `printf "%b"` to reliably format the input for Fuzzel, ensuring that icons are displayed correctly and the list is not on a single line.
- **Usage-Based Sorting**: Applications are sorted by frequency of use.
- **Robust Caching**: Uses an intelligent JSON cache for performance.
- The Hyprland keybinding for `SUPER+SPACE` is updated to use this script.

feat(nvim): Auto-quit when only special buffers remain

This adds an autocommand to Neovim to automatically quit when the last "normal" buffer is closed, leaving only special windows like the 'snacks' file explorer open. This is achieved by a robust Lua function that checks all open windows on the `BufEnter` event.