### PR TITLE
feat: Final fixes for Fuzzel script and Neovim config

### DIFF
--- a/nvim/lua/plugins/languages.lua
+++ b/nvim/lua/plugins/languages.lua
@@ -14,7 +14,6 @@ return {
           "pyright",
           "rust_analyzer",
           "gopls",
-          "bashls",
           "marksman",
           "lemminx",
           "clangd",


### PR DESCRIPTION
This commit applies a final round of fixes to both the Fuzzel launcher and the Neovim configuration based on user feedback.

Fuzzel (`fuzzel-apps.sh`):
- Correctly parses `.desktop` files to prioritize English names.
- Fixes a list formatting issue by properly escaping newlines in app names.
- Improves app launching compatibility (especially for Flatpak/Gnome apps) by using `bash -c`.

Neovim (`autocmds.lua`, `languages.lua`):
- Fixes a crash on startup by preventing the auto-quit logic from triggering when the dashboard is open.
- Fixes an LSP error on opening shell scripts by removing `bashls` from the list of auto-installed language servers.