### PR TITLE
feat: Final updates for Fuzzel script and Neovim config

### DIFF
--- a/hypr/hyprland/scripts/fuzzel-apps.sh
+++ b/hypr/hyprland/scripts/fuzzel-apps.sh
@@ -136,9 +136,9 @@ tmp_history_file=$(mktemp)
 jq --arg name "$chosen_app_name" '.[$name] = (.[$name] // 0) + 1' <(jq . "$HISTORY_FILE" 2>/dev/null || echo "{}") > "$tmp_history_file" && mv "$tmp_history_file" "$HISTORY_FILE"
 
 if [ "$is_terminal" = "true" ]; then
-    hyprctl dispatch exec -- "$TERMCMD" bash -c "$exec_cmd"
+    nohup "$TERMCMD" bash -c "$exec_cmd" >/dev/null 2>&1 &
 else
-    hyprctl dispatch exec -- bash -c "$exec_cmd"
+    nohup bash -c "$exec_cmd" >/dev/null 2>&1 &
 fi
 
 exit 0


### PR DESCRIPTION
This commit applies the final round of fixes to both the Fuzzel launcher and the Neovim configuration based on user feedback.

Fuzzel (`fuzzel-apps.sh`):
- Reverts the application launch method to use `nohup ... &` instead of `hyprctl dispatch exec`, as requested.
- Ensures correct parsing of `.desktop` files to prioritize English names.
- Fixes a list formatting issue by properly escaping newlines in app names.
- Uses `bash -c` for a more robust application launch environment.

Neovim (`autocmds.lua`, `languages.lua`):
- Fixes a crash on startup by preventing the auto-quit logic from triggering when the dashboard is open.
- Fixes an LSP error on opening shell scripts by removing `bashls` from the list of auto-installed language servers.