### PR TITLE
fix(hypr): Correct fuzzel-apps.sh script issues

### DIFF
--- a/hypr/hyprland/scripts/fuzzel-apps.sh
+++ b/hypr/hyprland/scripts/fuzzel-apps.sh
@@ -110,10 +110,10 @@ apps_with_history=$(
 sorted_apps=$(echo "$apps_with_history" | jq 'sort_by(-.count, .name)')
 
 # --- Fuzzel Execution ---
-fuzzel_input_template=$(echo "$sorted_apps" | jq -r '.[] | .name + "\\0icon\\x1f" + (.icon // "application-x-executable") + "\\n"')
+fuzzel_input_template=$(echo "$sorted_apps" | jq -r '.[] | .name + "\\0icon\\x1f" + (.icon // "application-x-executable")')
 
 chosen_app_name=""
-if ! chosen_app_name=$(printf "%b" "$fuzzel_input_template" | fuzzel --dmenu --log-level=none); then
+if ! chosen_app_name=$(printf "%b\n" "$fuzzel_input_template" | fuzzel --dmenu --log-level=none); then
     exit 0
 fi
 
@@ -138,7 +138,7 @@ jq --arg name "$chosen_app_name" '.[$name] = (.[$name] // 0) + 1' <(jq . "$HISTO
 if [ "$is_terminal" = "true" ]; then
     nohup "$TERMCMD" bash -c "$exec_cmd" >/dev/null 2>&1 &
 else
-    nohup bash -c "$exec_cmd" >/dev/null 2>&1 &
+    nohup bash -l -c "$exec_cmd" >/dev/null 2>&1 &
 fi
 
 exit 0


### PR DESCRIPTION
The fuzzel-apps.sh script had two issues:
1. Empty entries were displayed in the fuzzel menu due to extra newlines in the input stream.
2. Applications launched from Hyprland would not execute correctly as they were not launched with a complete shell environment.

This commit addresses both issues:
- The `jq` command that generates the application list is modified to avoid creating extra newlines.
- Non-terminal applications are now launched using `bash -l -c`, which ensures they are executed within a login shell, providing them with the necessary environment variables.