### PR TITLE
fix(fuzzel-apps): Ensure script runs correctly and improve launching

### DIFF
--- a/hypr/hyprland/scripts/fuzzel-apps.sh
+++ b/hypr/hyprland/scripts/fuzzel-apps.sh
@@ -16,10 +16,8 @@ export PATH="$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin"
 set -euo pipefail
 
 # --- Debugging ---
-# Enable with FUZZEL_DEBUG=1
 debug() {
-    # Notice the change here to '-ne 0' to catch any non-zero value
-    [ "${FUZZEL_DEBUG:-0}" -ne 0 ] && echo "DEBUG: $1" >&2
+    echo "DEBUG: $1" >&2
 }
 
 debug "Script started."
@@ -240,12 +238,14 @@ main() {
 
     # Launch the application
     if [ "$is_terminal" = "true" ]; then
-        debug "Launching in terminal: $TERMCMD zsh -c \"$exec_cmd\""
-        nohup "$TERMCMD" zsh -c "$exec_cmd" >/dev/null 2>&1 &
+        # Use an interactive shell to ensure aliases/functions are available.
+        debug "Launching in terminal: $TERMCMD zsh -i -c \"$exec_cmd\""
+        nohup "$TERMCMD" zsh -i -c "$exec_cmd" >/dev/null 2>&1 &
     else
-        # Use a login shell to ensure the user's environment is loaded
-        debug "Launching directly: zsh -l -c \"$exec_cmd\""
-        nohup zsh -l -c "$exec_cmd" >/dev/null 2>&1 &
+        # Use a login, interactive shell to ensure the user's full environment is loaded,
+        # including aliases and functions from .zshrc.
+        debug "Launching directly: zsh -l -i -c \"$exec_cmd\""
+        nohup zsh -l -i -c "$exec_cmd" >/dev/null 2>&1 &
     fi
     debug "Script finished."
 }


### PR DESCRIPTION
This commit addresses several issues found during testing:
- Removes the conditional `FUZZEL_DEBUG` logic to make debug messages unconditional, as requested.
- Fixes a bug where the script would only run when a debug flag was set, due to `set -e` interacting incorrectly with the original debug function.
- Makes the application launch command use an interactive shell (`zsh -i -c`) to ensure the user's full environment (aliases, functions) is loaded, fixing cases where apps wouldn't launch when run from Hyprland.