### PR TITLE
fix(fuzzel-apps): Add critical environment variables to fix launching

### DIFF
--- a/hypr/hyprland/scripts/fuzzel-apps.sh
+++ b/hypr/hyprland/scripts/fuzzel-apps.sh
@@ -6,12 +6,26 @@
 export LANG=en_US.UTF-8
 export LC_ALL=en_US.UTF-8
 
+# --- Critical Environment for GUI Apps ---
+# Pass through essential variables for Wayland/XWayland and DBus,
+# providing sensible defaults based on the user's environment if they are not set.
+export DISPLAY="${DISPLAY:-:0}"
+export DBUS_SESSION_BUS_ADDRESS="${DBUS_SESSION_BUS_ADDRESS:-unix:path=/run/user/$(id -u)/bus}"
+export XDG_CURRENT_DESKTOP="${XDG_CURRENT_DESKTOP:-Hyprland}"
+export XDG_SESSION_DESKTOP="${XDG_SESSION_DESKTOP:-Hyprland}"
+export XDG_SESSION_TYPE="${XDG_SESSION_TYPE:-wayland}"
+export GDK_BACKEND="${GDK_BACKEND:-wayland}"
+export QT_QPA_PLATFORM="${QT_QPA_PLATFORM:-wayland}"
+export SDL_VIDEODRIVER="${SDL_VIDEODRIVER:-wayland}"
+export MOZ_ENABLE_WAYLAND="${MOZ_ENABLE_WAYLAND:-1}"
+export _JAVA_AWT_WM_NONREPARENTING=1
+
 # --- Wayland & Path Environment ---
 # Ensure essential Wayland variables are set
 export WAYLAND_DISPLAY="${WAYLAND_DISPLAY:-wayland-1}"
 export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
-# Set a robust PATH
-export PATH="$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin"
+# Set a robust PATH. We prepend the user's existing PATH if available.
+export PATH="$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin${PATH:+:$PATH}"
 
 set -euo pipefail
 


### PR DESCRIPTION
This commit adds a comprehensive set of environment variables to the script, based on the user's provided environment. This is intended to be the final fix for the issue where applications would not launch when the script was called from Hyprland's `exec` context.

The new variables include:
- `DISPLAY` for XWayland compatibility.
- `DBUS_SESSION_BUS_ADDRESS` for inter-application communication.
- Various `XDG_*`, `GDK_BACKEND`, `QT_QPA_PLATFORM`, etc. to ensure GUI toolkits initialize correctly in a Wayland session.
- The `PATH` is now correctly preserved by appending the system PATH to the script's minimal one.