### PR TITLE
feat: Update hyprland configs to use uwsm

### DIFF
--- a/hypr/hyprland/execs.conf
+++ b/hypr/hyprland/execs.conf
@@ -5,30 +5,30 @@ exec-once = dbus-update-activation-environment --systemd --all
 exec-once = systemctl --user restart xdg-desktop-portal
 
 # Start polkit agent for authentication
-exec-once = /usr/lib/polkit-kde-authentication-agent-1
+exec-once = uwsm app -- /usr/lib/polkit-kde-authentication-agent-1
 
 # Start gnome-keyring for secrets
-exec-once = gnome-keyring-daemon --start --components=secrets
+exec-once = uwsm app -- gnome-keyring-daemon --start --components=secrets
 
 
 # Bar, wallpaper, and other UI elements
 # ------------------------------------
-exec-once = waybar -c ~/.config/waybar/config.jsonc -s ~/.config/waybar/themes/style.css &
-exec-once = hyprpaper &
-exec-once = ~/.config/hypr/hyprland/scripts/start_geoclue_agent.sh
+exec-once = uwsm app -- waybar -c ~/.config/waybar/config.jsonc -s ~/.config/waybar/themes/style.css
+exec-once = uwsm app -- hyprpaper
+exec-once = uwsm app -- ~/.config/hypr/hyprland/scripts/start_geoclue_agent.sh
 
 
 # Background services and daemons
 # ------------------------------------
 # Input method
-exec-once = fcitx5
+exec-once = uwsm app -- fcitx5
 
 # Audio
-exec-once = easyeffects --gapplication-service
+exec-once = uwsm app -- easyeffects --gapplication-service
 
 # Clipboard manager
-exec-once = wl-paste --type text --watch cliphist store
-exec-once = wl-paste --type image --watch cliphist store
+exec-once = uwsm app -- wl-paste --type text --watch cliphist store
+exec-once = uwsm app -- wl-paste --type image --watch cliphist store
 
 # Hyprland Plugin Manager
 exec-once = hyprpm reload

--- a/hypr/hyprland/keybinds.conf
+++ b/hypr/hyprland/keybinds.conf
@@ -8,33 +8,33 @@ bindld = Super+Shift,M, Toggle mute, exec, wpctl set-mute @DEFAULT_SINK@ toggle
 bindl = Alt ,XF86AudioMute, exec, wpctl set-mute @DEFAULT_SOURCE@ toggle 
 bindl = ,XF86AudioMicMute, exec, wpctl set-mute @DEFAULT_SOURCE@ toggle 
 bindld = Super+Alt,M, Toggle mic, exec, wpctl set-mute @DEFAULT_SOURCE@ toggle 
-bind = Ctrl+Super, R, exec, killall waybar && waybar -c ~/.config/waybar/config.jsonc -s ~/.config/waybar/themes/style.css & # Restart widgets
+bind = Ctrl+Super, R, exec, uwsm app -- sh -c 'killall waybar && waybar -c ~/.config/waybar/config.jsonc -s ~/.config/waybar/themes/style.css' # Restart widgets
 
 # Apps
 #bind = Super, Space, exec, $HOME/.config/hypr/hyprland/scripts/fuzzel-apps.sh
 #bind = SUPER, SPACE, exec, "export FUZZEL_DEBUG=1 /home/mclellac/.config/hypr/hyprland/scripts/fuzzel-apps.sh >> /tmp/fuzzel-debug.log 2>&1"
-bind = SUPER, SPACE, exec, ~/.config/hypr/hyprland/scripts/fuzzel-apps.sh
+bind = SUPER, SPACE, exec, uwsm app -- ~/.config/hypr/hyprland/scripts/fuzzel-apps.sh
 # bind = Super, V, exec, cliphist list | fuzzel -d | cliphist decode | wl-copy
-bind = Super+Alt, W, exec, ~/.config/hypr/custom/scripts/set-wallpaper.sh
+bind = Super+Alt, W, exec, uwsm app -- ~/.config/hypr/custom/scripts/set-wallpaper.sh
 
 # Utilities
 # Screenshot, Record, OCR, Color picker, Clipboard history
 # Hyprexpo
 # bind = CTRL_SUPER, Up, hyprexpo:expo, toggle
-bindd = Super, V, Copy clipboard history entry, exec, pkill fuzzel || cliphist list | fuzzel --match-mode fzf --dmenu | cliphist decode | wl-copy
-bindd = Super, Period, Copy an emoji, exec, pkill fuzzel || ~/.config/hypr/hyprland/scripts/fuzzel-emoji.sh copy
-bindd = Super+Shift, S, Screen snip, exec, pidof slurp || hyprshot --freeze --clipboard-only --mode region --silent
+bindd = Super, V, Copy clipboard history entry, exec, uwsm app -- sh -c 'pkill fuzzel || cliphist list | fuzzel --match-mode fzf --dmenu | cliphist decode | wl-copy'
+bindd = Super, Period, Copy an emoji, exec, uwsm app -- sh -c 'pkill fuzzel || ~/.config/hypr/hyprland/scripts/fuzzel-emoji.sh copy'
+bindd = Super+Shift, S, Screen snip, exec, uwsm app -- sh -c 'pidof slurp || hyprshot --freeze --clipboard-only --mode region --silent'
 # OCR
-bindd = Super+Shift, T, Character recognition,exec,grim -g "$(slurp $SLURP_ARGS)" "tmp.png" && tesseract "tmp.png" - | wl-copy && rm "tmp.png"
+bindd = Super+Shift, T, Character recognition,exec,uwsm app -- sh -c 'grim -g "$(slurp $SLURP_ARGS)" "tmp.png" && tesseract "tmp.png" - | wl-copy && rm "tmp.png"'
 # Color picker
-bindd = Super+Shift, C, Color picker, exec, hyprpicker -a
+bindd = Super+Shift, C, Color picker, exec, uwsm app -- hyprpicker -a
 # Fullscreen screenshot
-bindld = ,Print, Screenshot >> clipboard ,exec,grim - | wl-copy
-bindld = Ctrl,Print, Screenshot >> clipboard & save, exec, mkdir -p $(xdg-user-dir PICTURES)/Screenshots && grim $(xdg-user-dir PICTURES)/Screenshots/Screenshot_"$(date '+%Y-%m-%d_%H.%M.%S')".png
+bindld = ,Print, Screenshot >> clipboard ,exec,uwsm app -- sh -c 'grim - | wl-copy'
+bindld = Ctrl,Print, Screenshot >> clipboard & save, exec, uwsm app -- sh -c 'mkdir -p $(xdg-user-dir PICTURES)/Screenshots && grim $(xdg-user-dir PICTURES)/Screenshots/Screenshot_"$(date '\''+%Y-%m-%d_%H.%M.%S'\'')".png'
 # Recording stuff
-bindd = Super+Alt, R, Record region (no sound), exec, ~/.config/hypr/hyprland/scripts/record.sh
-bindd = Ctrl+Alt, R, Record screen (no sound), exec, ~/.config/hypr/hyprland/scripts/record.sh --fullscreen
-bindd = Super+Shift+Alt, R, Record screen (with sound), exec, ~/.config/hypr/hyprland/scripts/record.sh --fullscreen-sound
+bindd = Super+Alt, R, Record region (no sound), exec, uwsm app -- ~/.config/hypr/hyprland/scripts/record.sh
+bindd = Ctrl+Alt, R, Record screen (no sound), exec, uwsm app -- ~/.config/hypr/hyprland/scripts/record.sh --fullscreen
+bindd = Super+Shift+Alt, R, Record screen (with sound), exec, uwsm app -- ~/.config/hypr/hyprland/scripts/record.sh --fullscreen-sound
 # AI
 # bindd = Super+Shift+Alt, mouse:273, Generate AI summary for selected text, exec, ~/.config/hypr/hyprland/scripts/ai/primary-buffer-query.sh
 
@@ -147,8 +147,8 @@ bind = Ctrl+Super, Down, workspace, r+5
 
 # Screen
 # Zoom
-binde = Super, Minus, exec, ~/.config/hypr/hyprland/scripts/zoom.sh decrease 0.1 # Zoom out
-binde = Super, Equal, exec, ~/.config/hypr/hyprland/scripts/zoom.sh increase 0.1 # Zoom in
+binde = Super, Minus, exec, uwsm app -- ~/.config/hypr/hyprland/scripts/zoom.sh decrease 0.1 # Zoom out
+binde = Super, Equal, exec, uwsm app -- ~/.config/hypr/hyprland/scripts/zoom.sh increase 0.1 # Zoom in
 
 # Media
 bindl= Super+Shift, N, exec, playerctl next || playerctl position `bc <<< "100 * $(playerctl metadata mpris:length) / 1000000 / 100"` # Next track
@@ -162,17 +162,17 @@ bindl= ,XF86AudioPlay, exec, playerctl play-pause
 bindl= ,XF86AudioPause, exec, playerctl play-pause 
 
 # Apps
-bind = Super, Return, exec, ~/.config/hypr/hyprland/scripts/launch_first_available.sh "kitty -1" "foot" "alacritty" "wezterm" "konsole" "kgx" "uxterm" "xterm" # Terminal
-bind = Super, T, exec, ~/.config/hypr/hyprland/scripts/launch_first_available.sh "kitty -1" "foot" "alacritty" "wezterm" "konsole" "kgx" "uxterm" "xterm" # Kitty (terminal) (alt)
-bind = Ctrl+Alt, T, exec, ~/.config/hypr/hyprland/scripts/launch_first_available.sh "kitty -1" "foot" "alacritty" "wezterm" "konsole" "kgx" "uxterm" "xterm" # Kitty (for Ubuntu people)
-bind = Super, E, exec, ~/.config/hypr/hyprland/scripts/launch_first_available.sh "nautilus" "dolphin" "nemo" "thunar" "kitty -1 fish -c yazi" # File manager
-bind = Super, W, exec, ~/.config/hypr/hyprland/scripts/launch_first_available.sh "google-chrome-stable" "zen-browser" "firefox" "epiphany" "brave" "chromium" "microsoft-edge-stable" "opera" "librewolf" # Browser
-bind = Super, C, exec, ~/.config/hypr/hyprland/scripts/launch_first_available.sh "code" "code-insiders" "codium" "cursor" "zed" "zedit" "zeditor" "kate" "gnome-text-editor" "emacs" "command -v nvim && kitty -1 nvim" # Code editor
-bind = Super+Shift, W, exec, ~/.config/hypr/hyprland/scripts/launch_first_available.sh "wps" "onlyoffice-desktopeditors" # Office software
-bind = Super, X, exec, ~/.config/hypr/hyprland/scripts/launch_first_available.sh "kate" "gnome-text-editor" "emacs" # Text editor
-bind = Ctrl+Super, V, exec, ~/.config/hypr/hyprland/scripts/launch_first_available.sh "pavucontrol-qt" "pavucontrol" # Volume mixer
-bind = Super, I, exec, XDG_CURRENT_DESKTOP=gnome ~/.config/hypr/hyprland/scripts/launch_first_available.sh "systemsettings" "gnome-control-center" "better-control" # Settings app
-bind = Ctrl+Shift, Escape, exec, ~/.config/hypr/hyprland/scripts/launch_first_available.sh "gnome-system-monitor" "plasma-systemmonitor --page-name Processes" "command -v btop && kitty -1 fish -c btop" # Task manager
+bind = Super, Return, exec, uwsm app -- ~/.config/hypr/hyprland/scripts/launch_first_available.sh "kitty -1" "foot" "alacritty" "wezterm" "konsole" "kgx" "uxterm" "xterm" # Terminal
+bind = Super, T, exec, uwsm app -- ~/.config/hypr/hyprland/scripts/launch_first_available.sh "kitty -1" "foot" "alacritty" "wezterm" "konsole" "kgx" "uxterm" "xterm" # Kitty (terminal) (alt)
+bind = Ctrl+Alt, T, exec, uwsm app -- ~/.config/hypr/hyprland/scripts/launch_first_available.sh "kitty -1" "foot" "alacritty" "wezterm" "konsole" "kgx" "uxterm" "xterm" # Kitty (for Ubuntu people)
+bind = Super, E, exec, uwsm app -- ~/.config/hypr/hyprland/scripts/launch_first_available.sh "nautilus" "dolphin" "nemo" "thunar" "kitty -1 fish -c yazi" # File manager
+bind = Super, W, exec, uwsm app -- ~/.config/hypr/hyprland/scripts/launch_first_available.sh "google-chrome-stable" "zen-browser" "firefox" "epiphany" "brave" "chromium" "microsoft-edge-stable" "opera" "librewolf" # Browser
+bind = Super, C, exec, uwsm app -- ~/.config/hypr/hyprland/scripts/launch_first_available.sh "code" "code-insiders" "codium" "cursor" "zed" "zedit" "zeditor" "kate" "gnome-text-editor" "emacs" "command -v nvim && kitty -1 nvim" # Code editor
+bind = Super+Shift, W, exec, uwsm app -- ~/.config/hypr/hyprland/scripts/launch_first_available.sh "wps" "onlyoffice-desktopeditors" # Office software
+bind = Super, X, exec, uwsm app -- ~/.config/hypr/hyprland/scripts/launch_first_available.sh "kate" "gnome-text-editor" "emacs" # Text editor
+bind = Ctrl+Super, V, exec, uwsm app -- ~/.config/hypr/hyprland/scripts/launch_first_available.sh "pavucontrol-qt" "pavucontrol" # Volume mixer
+bind = Super, I, exec, uwsm app -- sh -c 'XDG_CURRENT_DESKTOP=gnome ~/.config/hypr/hyprland/scripts/launch_first_available.sh "systemsettings" "gnome-control-center" "better-control"' # Settings app
+bind = Ctrl+Shift, Escape, exec, uwsm app -- ~/.config/hypr/hyprland/scripts/launch_first_available.sh "gnome-system-monitor" "plasma-systemmonitor --page-name Processes" "command -v btop && kitty -1 fish -c btop" # Task manager
 
 # Cursed stuff
 ## Make window not amogus large


### PR DESCRIPTION
Updates the hyprland configuration to use `uwsm app --` for launching applications.

This is done for both `exec-once` commands in `execs.conf` and for keybindings in `keybinds.conf`.

For commands that use shell features like `&&` or `||`, the command is wrapped in `sh -c '...'`.