### PR TITLE
fix(hypr): Launch apps from fuzzel with login shell

### DIFF
--- a/hypr/hyprland/scripts/fuzzel-apps.sh
+++ b/hypr/hyprland/scripts/fuzzel-apps.sh
@@ -244,9 +244,8 @@ main() {
     else
         # Use a login, interactive shell to ensure the user's full environment is loaded,
         # including aliases and functions from .zshrc.
-        #debug "Launching directly: zsh -l -i -c \"$exec_cmd\""
-        debug "uwsm app $exec_cmd"
-        uwsm app "$exec_cmd"
+        debug "Launching with: nohup zsh -l -i -c \"$exec_cmd\""
+        nohup zsh -l -i -c "$exec_cmd" >/dev/null 2>&1 &
     fi
     debug "Script finished."
 }


### PR DESCRIPTION
GNOME applications were failing to launch from the fuzzel application launcher. This was because the applications were being launched in a minimal environment that lacked the necessary environmental variables set by a login shell.

This change modifies the `fuzzel-apps.sh` script to use a login, interactive shell (`zsh -l -i -c`) to execute the chosen application. This ensures that the application is launched with the full user environment, including all necessary D-Bus and XDG-related variables, allowing GNOME applications to start correctly.

The command is run with `nohup` and in the background to prevent it from being killed when the parent script exits and to avoid blocking the UI.