### PR TITLE
fix(hypr): Launch apps from fuzzel with direct execution

### DIFF
--- a/hypr/hyprland/scripts/fuzzel-apps.sh
+++ b/hypr/hyprland/scripts/fuzzel-apps.sh
@@ -244,8 +244,8 @@ main() {
     else
         # Use a login, interactive shell to ensure the user's full environment is loaded,
         # including aliases and functions from .zshrc.
-        debug "Launching with: nohup zsh -l -i -c \"$exec_cmd\""
-        nohup zsh -l -i -c "$exec_cmd" >/dev/null 2>&1 &
+        debug "Launching with: eval \"LIBGL_ALWAYS_SOFTWARE=1 $exec_cmd\" &"
+        eval "LIBGL_ALWAYS_SOFTWARE=1 $exec_cmd" &
     fi
     debug "Script finished."
 }


### PR DESCRIPTION
GNOME applications were failing to launch from the fuzzel application launcher. The previous implementation used a nested call to `uwsm app`, which appears to be incorrect and caused issues with the application's execution context.

This change modifies `fuzzel-apps.sh` to launch applications directly, mirroring the successful launch method used by other keybindings in the configuration. The script now uses `eval` to execute the command in the background.

Additionally, the `LIBGL_ALWAYS_SOFTWARE=1` environment variable is prepended to the command. This is a common workaround for rendering issues with some applications on Wayland and is used in the working `launch_first_available.sh` script, suggesting it may be beneficial for stability.