### PR TITLE
fix: Correct keybinding for increasing window gap size

### DIFF
--- a/hypr/custom/keybinds.conf
+++ b/hypr/custom/keybinds.conf
@@ -10,7 +10,7 @@
 # Add a comment after a bind to add a description, like above
 
 ##! Layout
-bind = SUPER SHIFT, plus, exec, zsh -c "hyprctl keyword general:gaps_in $(($(hyprctl getoption general:gaps_in | jq .int) + 5))"
+bind = SUPER SHIFT, equal, exec, zsh -c "hyprctl keyword general:gaps_in $(($(hyprctl getoption general:gaps_in | jq .int) + 5))"
 bind = SUPER SHIFT, minus, exec, zsh -c "hyprctl keyword general:gaps_in $(($(hyprctl getoption general:gaps_in | jq .int) - 5))"
 
 ##! Apps


### PR DESCRIPTION
This commit fixes an issue where the keybinding to increase the window gap size (`SUPER+SHIFT+PLUS`) was not working.

The key name `plus` was incorrect. It has been replaced with `equal`, which is the correct keysym for the key that produces `+` when pressed with `SHIFT` on most keyboards.

The keybinding in `hypr/custom/keybinds.conf` is now: `bind = SUPER SHIFT, equal, exec, ...`

This ensures that the keybinding works as expected.