### PR TITLE
fix: Implement incremental gap adjustment with a script

### DIFF
--- a/hypr/custom/keybinds.conf
+++ b/hypr/custom/keybinds.conf
@@ -10,8 +10,8 @@
 # Add a comment after a bind to add a description, like above
 
 ##! Layout
-bind = SUPER SHIFT, equal, exec, zsh -c "hyprctl keyword general:gaps_in $(($(hyprctl getoption general:gaps_in | jq .int) + 5))"
-bind = SUPER SHIFT, minus, exec, zsh -c "hyprctl keyword general:gaps_in $(($(hyprctl getoption general:gaps_in | jq .int) - 5))"
+bind = SUPER SHIFT, equal, exec, ~/.config/hypr/custom/scripts/adjust_gaps.sh inc
+bind = SUPER SHIFT, minus, exec, ~/.config/hypr/custom/scripts/adjust_gaps.sh dec
 
 ##! Apps
 #bind = Super, Space, exec, zsh -ic "fuzzel"

--- a/hypr/custom/scripts/adjust_gaps.sh
+++ b/hypr/custom/scripts/adjust_gaps.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Path for the state file
+STATE_FILE="/tmp/hypr_gaps.state"
+
+# Default gap size if state file doesn't exist
+# This should ideally match your hyprland.conf initial value
+DEFAULT_GAPS=5
+
+# Step size for increasing/decreasing gaps
+STEP=5
+
+# Read current gap size from state file, or use default
+if [ -f "$STATE_FILE" ]; then
+    current_gaps=$(cat "$STATE_FILE")
+else
+    # If state file doesn't exist, try to get it from hyprctl, fallback to default
+    current_gaps=$(hyprctl getoption general:gaps_in | jq .int 2>/dev/null)
+    if [ -z "$current_gaps" ]; then
+        current_gaps=$DEFAULT_GAPS
+    fi
+fi
+
+# Adjust gaps based on argument
+if [ "$1" == "inc" ]; then
+    new_gaps=$((current_gaps + STEP))
+elif [ "$1" == "dec" ]; then
+    new_gaps=$((current_gaps - STEP))
+    # Prevent gaps from being negative
+    if [ "$new_gaps" -lt 0 ]; then
+        new_gaps=0
+    fi
+else
+    echo "Usage: $0 [inc|dec]"
+    exit 1
+fi
+
+# Apply the new gap size
+hyprctl keyword general:gaps_in "$new_gaps"
+
+# Save the new gap size to the state file
+echo "$new_gaps" > "$STATE_FILE"


### PR DESCRIPTION
This commit resolves an issue where the window gap size was not adjusting incrementally. The previous method of using `hyprctl getoption` within the keybinding was not reliable for fetching the live state of the gap size.

To fix this, a new script `hypr/custom/scripts/adjust_gaps.sh` has been introduced. This script manages the state of the window gap size in a temporary file (`/tmp/hypr_gaps.state`), allowing for true incremental adjustments.

The keybindings in `hypr/custom/keybinds.conf` have been updated to call this new script, ensuring that the gap size can be increased and decreased incrementally as intended.