### PR TITLE
Fix theme loading by correcting theme path

### DIFF
--- a/hypr/bin/omarchy-menu
+++ b/hypr/bin/omarchy-menu
@@ -251,7 +251,7 @@ show_install_gaming_menu() {
 show_install_style_menu() {
   case $(menu "Install" "󰸌  Theme\n  Background\n  Font") in
   *Theme*) present_terminal omarchy-theme-install ;;
-  *Background*) nautilus ~/.config/omarchy/current/theme/backgrounds ;;
+  *Background*) nautilus ~/.config/hypr/theme/backgrounds ;;
   *Font*) show_install_font_menu ;;
   *) show_install_menu ;;
   esac

--- a/hypr/bin/omarchy-theme-bg-next
+++ b/hypr/bin/omarchy-theme-bg-next
@@ -2,7 +2,7 @@
 
 # Cycles through the background images available
 
-BACKGROUNDS_DIR="$HOME/.config/omarchy/current/theme/backgrounds/"
+BACKGROUNDS_DIR="$HOME/.config/hypr/theme/backgrounds/"
 CURRENT_BACKGROUND_LINK="$HOME/.config/omarchy/current/background"
 
 mapfile -d '' -t BACKGROUNDS < <(find "$BACKGROUNDS_DIR" -type f -print0 | sort -z)

--- a/hypr/bin/omarchy-theme-current
+++ b/hypr/bin/omarchy-theme-current
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-basename "$(realpath "$HOME/.config/omarchy/current/theme")" | sed -E 's/(^|-)([a-z])/\1\u\2/g; s/-/ /g'
+basename "$(realpath "$HOME/.config/hypr/theme")" | sed -E 's/(^|-)([a-z])/\1\u\2/g; s/-/ /g'

--- a/hypr/bin/omarchy-theme-next
+++ b/hypr/bin/omarchy-theme-next
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-THEMES_DIR="$HOME/.config/omarchy/themes/"
-CURRENT_THEME_LINK="$HOME/.config/omarchy/current/theme"
+THEMES_DIR="$HOME/.config/hypr/themes/"
+CURRENT_THEME_LINK="$HOME/.config/hypr/theme"
 
 THEMES=($(find "$THEMES_DIR" -mindepth 1 -maxdepth 1 | sort))
 TOTAL=${#THEMES[@]}

--- a/hypr/bin/omarchy-theme-set
+++ b/hypr/bin/omarchy-theme-set
@@ -9,7 +9,7 @@ if [[ -z "$1" && "$1" != "CNCLD" ]]; then
 fi
 
 THEMES_DIR="$HOME/.config/hypr/themes/"
-CURRENT_THEME_DIR="$HOME/.config/omarchy/current/theme"
+CURRENT_THEME_DIR="$HOME/.config/hypr/theme"
 
 THEME_NAME=$(echo "$1" | sed -E 's/<[^>]+>//g' | tr '[:upper:]' '[:lower:]' | tr ' ' '-')
 THEME_PATH="$THEMES_DIR/$THEME_NAME"
@@ -24,7 +24,7 @@ fi
 ln -nsf "$THEME_PATH" "$CURRENT_THEME_DIR"
 
 # Change gnome modes
-if [[ -f ~/.config/omarchy/current/theme/light.mode ]]; then
+if [[ -f ~/.config/hypr/theme/light.mode ]]; then
   gsettings set org.gnome.desktop.interface color-scheme "prefer-light"
   gsettings set org.gnome.desktop.interface gtk-theme "Adwaita"
 else
@@ -33,22 +33,22 @@ else
 fi
 
 # Change gnome icon theme color
-if [[ -f ~/.config/omarchy/current/theme/icons.theme ]]; then
-  gsettings set org.gnome.desktop.interface icon-theme "$(<~/.config/omarchy/current/theme/icons.theme)"
+if [[ -f ~/.config/hypr/theme/icons.theme ]]; then
+  gsettings set org.gnome.desktop.interface icon-theme "$(<~/.config/hypr/theme/icons.theme)"
 else
   gsettings set org.gnome.desktop.interface icon-theme "Yaru-blue"
 fi
 
 # Change Chromium colors
 if command -v chromium &>/dev/null; then
-  if [[ -f ~/.config/omarchy/current/theme/light.mode ]]; then
+  if [[ -f ~/.config/hypr/theme/light.mode ]]; then
     chromium --no-startup-window --set-color-scheme="light"
   else
     chromium --no-startup-window --set-color-scheme="dark"
   fi
 
-  if [[ -f ~/.config/omarchy/current/theme/chromium.theme ]]; then
-    chromium --no-startup-window --set-theme-color="$(<~/.config/omarchy/current/theme/chromium.theme)"
+  if [[ -f ~/.config/hypr/theme/chromium.theme ]]; then
+    chromium --no-startup-window --set-theme-color="$(<~/.config/hypr/theme/chromium.theme)"
   else
     # Use a default, neutral grey if theme doesn't have a color
     chromium --no-startup-window --set-theme-color="28,32,39"

--- a/hypr/config/alacritty/alacritty.toml
+++ b/hypr/config/alacritty/alacritty.toml
@@ -1,4 +1,4 @@
-general.import = [ "~/.config/omarchy/current/theme/alacritty.toml" ]
+general.import = [ "~/.config/hypr/theme/alacritty.toml" ]
 
 [env]
 TERM = "xterm-256color"

--- a/hypr/config/hypr/hyprland.conf
+++ b/hypr/config/hypr/hyprland.conf
@@ -9,7 +9,7 @@ source = ~/.local/share/omarchy/default/hypr/envs.conf
 source = ~/.local/share/omarchy/default/hypr/looknfeel.conf
 source = ~/.local/share/omarchy/default/hypr/input.conf
 source = ~/.local/share/omarchy/default/hypr/windows.conf
-source = ~/.config/omarchy/current/theme/hyprland.conf
+source = ~/.config/hypr/theme/hyprland.conf
 
 # Change your own setup in these files (and overwrite any settings from defaults!)
 source = ~/.config/hypr/monitors.conf

--- a/hypr/config/hypr/hyprlock.conf
+++ b/hypr/config/hypr/hyprlock.conf
@@ -1,4 +1,4 @@
-source = ~/.config/omarchy/current/theme/hyprlock.conf
+source = ~/.config/hypr/theme/hyprlock.conf
 
 background {
     monitor =

--- a/hypr/config/swayosd/style.css
+++ b/hypr/config/swayosd/style.css
@@ -1,4 +1,4 @@
-@import "../omarchy/current/theme/swayosd.css";
+@import "../../theme/swayosd.css";
 
 window {
   border-radius: 0;

--- a/hypr/config/waybar/style.css
+++ b/hypr/config/waybar/style.css
@@ -1,4 +1,4 @@
-@import "../omarchy/current/theme/waybar.css";
+@import "../../theme/waybar.css";
 
 * {
   background-color: @background;

--- a/hypr/hyprland.conf
+++ b/hypr/hyprland.conf
@@ -9,7 +9,7 @@ source = ~/.local/share/omarchy/default/hypr/envs.conf
 source = ~/.local/share/omarchy/default/hypr/looknfeel.conf
 source = ~/.local/share/omarchy/default/hypr/input.conf
 source = ~/.local/share/omarchy/default/hypr/windows.conf
-source = ~/.config/omarchy/current/theme/hyprland.conf
+source = ~/.config/hypr/theme/hyprland.conf
 
 # Change your own setup in these files (and overwrite any settings from defaults!)
 source = ~/.config/hypr/monitors.conf


### PR DESCRIPTION
The theme loading mechanism was using a hardcoded path in `~/.config/omarchy/current/theme`. This was causing issues and was not robust, especially if a theme had never been set.

This change refactors the theme path to a more logical and self-contained location: `~/.config/hypr/theme`.

The following changes were made:
- Updated `hypr/hyprland.conf` and a duplicate at `hypr/config/hypr/hyprland.conf` to source the theme from the new path.
- Updated all theme-related scripts in `hypr/bin` to use the new theme path for creating and reading the theme symlink.
- Updated various application configuration files (`alacritty`, `hyprlock`, `swayosd`, `waybar`) to reference the new theme path.