### PR TITLE
docs: Document Hyprland configuration in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,88 @@ The script provides rich logging and error handling features to ensure smooth ex
 ### Customization
 
 Feel free to modify the script and the configuration file to suit your specific setup requirements. You can add new tasks, change package lists, or extend post-installation actions as needed.
+
+## Hyprland Configuration
+
+This section provides a detailed overview of the Hyprland window manager configuration used in this dotfiles repository. The setup is highly customized with a focus on aesthetics, usability, and a powerful theming system.
+
+### File Structure
+
+The core of the configuration resides in the `~/.config/hypr/` directory. Here's a breakdown of the key files and directories:
+
+-   `hyprland.conf`: The main entry point for Hyprland's configuration. It sources all other configuration files, creating a modular and easy-to-manage setup.
+-   `monitors.conf`: Defines monitor setups, resolutions, scaling, and workspaces. It includes commented-out examples for different types of displays (Retina, 4K, 1080p).
+-   `input.conf`: Configures input devices like keyboards and touchpads, including layout, repeat rate, and sensitivity.
+-   `bindings.conf`: Contains custom keybindings for launching applications, managing windows, and running scripts. This is where you can customize your keyboard shortcuts.
+-   `envs.conf`: Sets essential environment variables for the Hyprland session, ensuring applications run correctly under Wayland with proper theming.
+-   `autostart.conf`: Specifies applications and scripts to be launched automatically when Hyprland starts.
+-   `themes/`: This directory contains all available themes. Each theme is a subdirectory containing a complete set of configuration files for Hyprland and other applications.
+-   `theme/`: This directory holds the *currently active* theme. The files here are symlinks to the selected theme in the `themes/` directory. **Do not edit files in this directory directly.**
+-   `bin/`: Contains a collection of helper scripts that power much of the functionality of this setup, from theme switching to application launchers and system management menus.
+-   `scripts/`: Contains scripts that are used by Hyprland but are not intended to be run directly by the user.
+-   `config/`: Holds configuration files for other applications that are styled by the theming system, such as Alacritty, Waybar, and Walker.
+
+### Theming
+
+A powerful script-based theming system allows for a consistent look and feel across the entire desktop environment.
+
+-   **How it Works**: The `omarchy-theme-set <theme-name>` script creates symbolic links from the chosen theme's files in `hypr/themes/<theme-name>/` to the `hypr/theme/` directory. Hyprland and other applications are configured to load their settings from this `hypr/theme/` directory, instantly applying the new look.
+-   **Available Themes**: To see a list of all available themes, run `omarchy-theme-list`.
+-   **Switching Themes**: Use `omarchy-theme-set <theme-name>` to switch to a different theme. You can also use `omarchy-theme-next` to cycle through available themes.
+-   **Creating a New Theme**: The easiest way to create a new theme is to copy an existing one (`cp -r hypr/themes/rose-pine hypr/themes/my-awesome-theme`), customize the files within the new directory, and then apply it with `omarchy-theme-set my-awesome-theme`.
+
+### Keybindings
+
+The following keybindings are defined in `~/.config/hypr/bindings.conf`. This list covers application and web app launchers. For tiling, window management, and media keybindings, please refer to the files in `~/.config/hypr/default/hypr/bindings/`.
+
+| Keybinding | Description | Action |
+| --- | --- | --- |
+| `SUPER + Return` | Terminal | Opens a new terminal in the CWD of the active one |
+| `SUPER + F` | File manager | Opens Nautilus |
+| `SUPER + B` | Browser | Launches the default web browser |
+| `SUPER + M` | Music | Launches Spotify |
+| `SUPER + N` | Neovim | Launches Neovim in a new terminal |
+| `SUPER + T` | Activity | Launches btop in a new terminal |
+| `SUPER + D` | Docker | Launches lazydocker in a new terminal |
+| `SUPER + G` | Signal | Launches Signal Desktop |
+| `SUPER + O` | Obsidian | Launches Obsidian |
+| `SUPER + /` | Passwords | Launches 1Password |
+| `SUPER + A` | ChatGPT | Opens ChatGPT as a web app |
+| `SUPER + SHIFT + A` | Grok | Opens Grok as a web app |
+| `SUPER + C` | Calendar | Opens HEY Calendar as a web app |
+| `SUPER + E` | Email | Opens HEY Email as a web app |
+| `SUPER + Y` | YouTube | Opens YouTube as a web app |
+| `SUPER + SHIFT + G`| WhatsApp | Opens WhatsApp as a web app |
+| `SUPER + ALT + G` | Google Messages | Opens Google Messages as a web app |
+| `SUPER + X` | X | Opens X as a web app |
+| `SUPER + SHIFT + X`| X Post | Opens X compose page as a web app |
+
+### Scripts
+
+The `hypr/bin/` directory is filled with powerful `omarchy-` scripts. The most important one is `omarchy-menu`, which is typically bound to `SUPER + SPACE`. It provides a comprehensive, searchable menu system (using `walker`) to access almost all functionality of the desktop.
+
+The main categories in the menu include:
+
+-   **Apps**: Launch applications.
+-   **Learn**: Access documentation for Keybindings, Omarchy, Hyprland, etc.
+-   **Capture**: Take screenshots or screen recordings.
+-   **Toggle**: Enable/disable features like the screensaver, night light, or top bar.
+-   **Style**: Change the theme, font, or background.
+-   **Setup**: Configure system settings like Audio, Wifi, Bluetooth, Monitors, etc.
+-   **Install**: Install new packages, themes, fonts, and development environments.
+-   **Remove**: Uninstall packages, themes, etc.
+-   **Update**: Update the system, configs, and themes.
+-   **System**: Lock screen, suspend, restart, or shutdown.
+
+Other notable scripts include:
+-   `omarchy-launch-browser`: Launches the system's default web browser.
+-   `omarchy-launch-webapp`: Launches a URL as a standalone web application using your browser's `--app` feature.
+-   `omarchy-cmd-terminal-cwd`: A clever script that gets the working directory of the currently focused terminal, so that new terminals can be opened in the same path.
+
+### Customization
+
+-   **Keybindings**: To change or add keybindings, edit `~/.config/hypr/bindings.conf`.
+-   **Monitors**: Adjust your monitor layout, resolution, and scaling in `~/.config/hypr/monitors.conf`.
+-   **Startup Apps**: Add or remove startup applications in `~/.config/hypr/autostart.conf`.
+-   **Themes**: Create or modify themes in the `~/.config/hypr/themes/` directory.
+-   **Scripts**: You can modify any of the `omarchy-` scripts in `~/.config/hypr/bin/` to change their behavior.


### PR DESCRIPTION
Adds a comprehensive "Hyprland Configuration" section to the main README.md file.

This new section provides a detailed overview of the Hyprland setup, including:
- A breakdown of the file and directory structure in `~/.config/hypr`.
- An explanation of the script-based theming system and how to use it.
- A table of custom keybindings for launching applications.
- A description of the powerful `omarchy-` helper scripts, with a focus on the central `omarchy-menu`.
- Pointers on how to customize various aspects of the configuration.