### PR TITLE
This commit fixes several issues with the hypr configuration scripts.

### DIFF
--- a/hypr/bin/hypr-launch-floating-terminal-with-presentation
+++ b/hypr/bin/hypr-launch-floating-terminal-with-presentation
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-cmd="$*"
-setsid alacritty --class Hypr -e bash -c "hypr-show-logo; $cmd; hypr-show-done"
+setsid alacritty --class Hypr -e bash -c 'hypr-show-logo; eval "$1"; hypr-show-done' -- "$*"

--- a/hypr/bin/hypr-launch-webapp
+++ b/hypr/bin/hypr-launch-webapp
@@ -7,4 +7,4 @@ google-chrome* | brave-browser* | microsoft-edge* | opera* | vivaldi*) ;;
 *) browser="chromium.desktop" ;;
 esac
 
-exec setsid uwsm app -- $(sed -n 's/^Exec=\([^ ]*\).*/\1/p' {~/.local,~/.nix-profile,/usr}/share/applications/$browser 2>/dev/null | head -1) --app="$1" "${@:2}"
+exec setsid uwsm app -- $(sed -n 's/^Exec=\([^ ]*\).*/\1/p' ~/.local/share/applications/"$browser" ~/.nix-profile/share/applications/"$browser" /usr/share/applications/"$browser" 2>/dev/null | head -1) --app="$1" "${@:2}"

--- a/hypr/bin/hypr-theme-set
+++ b/hypr/bin/hypr-theme-set
@@ -69,6 +69,7 @@ touch "$HOME/.config/alacritty/alacritty.toml"
 pkill -SIGUSR2 btop
 hypr-restart-waybar
 hypr-restart-swayosd
+hypr-restart-walker
 makoctl reload
 hyprctl reload
 

--- a/hypr/config/walker/config.toml
+++ b/hypr/config/walker/config.toml
@@ -1,7 +1,7 @@
 close_when_open = true
 theme = "default"
 theme_base = []
-theme_location = ["~/.config/hypr/default/walker/themes/"]
+theme_location = ["~/.config/hypr/theme", "~/.config/hypr/default/walker/themes/"]
 hotreload_theme = true
 force_keyboard_focus = true
 timeout = 60


### PR DESCRIPTION
- **Walker theme:** The walker theme was not being applied correctly because the configuration file was pointing to the wrong theme directory. This has been fixed by updating the `theme_location` in `walker/config.toml`. Additionally, the `hypr-theme-set` script has been updated to restart walker after a theme change.
- **Web app launcher:** The web app launcher was failing because of a bug in the `sed` command that was preventing it from finding the browser's executable. This has been fixed by correcting the path expansion.
- **Install menu:** The 'Install' menu item was not working correctly because the script that launches the terminal was not handling command arguments with spaces and quotes correctly. This has been fixed by using a more robust method of executing commands.