### PR TITLE
This commit fixes an issue with the `btop` reload script in the new m…

### DIFF
--- a/hypr/theme-reload.d/01-btop
+++ b/hypr/theme-reload.d/01-btop
@@ -1,2 +1,2 @@
 #!/bin/bash
-pkill -SIGUSR2 btop
+pkill -SIGUSR2 btop || true


### PR DESCRIPTION
…odular theming system.

The `btop` reload script was causing the `hypr-theme-set` script to exit if `btop` was not running. This was due to the `set -e` option in `hypr-theme-set` and the fact that `pkill` returns a non-zero exit code if no process is found.

The fix is to add `|| true` to the `pkill` command in the `btop` reload script. This ensures that the script always exits with a success status, even if `btop` is not running.