### PR TITLE
This commit fixes a recurring issue with the `btop` reload script and…

### DIFF
--- a/hypr/theme-reload.d/01-btop
+++ b/hypr/theme-reload.d/01-btop
@@ -1,2 +1,5 @@
 #!/bin/bash
-pkill -SIGUSR2 btop || true
+pid=$(pidof btop)
+if [[ -n "$pid" ]]; then
+    kill -SIGUSR2 "$pid"
+fi


### PR DESCRIPTION
… includes several other improvements to the hypr configuration scripts.

- **Fix `btop` Reload Script:** The `btop` reload script was causing the `hypr-theme-set` script to fail if `btop` was not running. The `pkill` command has been replaced with a more robust `pidof` and `kill` combination to prevent this issue.

- **Improve Script Robustness:** This commit also includes the previously implemented improvements:
    - **Dependency Checking:** Scripts now check for their dependencies before execution.
    - **Centralized Path Management:** Hardcoded paths have been replaced with the `HYPR_CONFIG_DIR` environment variable.
    - **Modular Theming System:** The `hypr-theme-set` script now uses a modular `theme-reload.d` directory.
    - **Improved User Feedback:** Scripts now provide desktop notifications using `notify-send`.