### PR TITLE
This commit fixes an issue where the `hypr-theme-set` script would te…

### DIFF
--- a/hypr/bin/hypr-restart-app
+++ b/hypr/bin/hypr-restart-app
@@ -1,4 +1,7 @@
 #!/bin/bash
+set -e
+source "$(dirname "$0")/hypr-utils"
+check_deps pkill setsid uwsm
 
-pkill -x $1
-setsid uwsm app -- $1 >/dev/null 2>&1 &
+pkill -x "$1" || true
+setsid uwsm app -- "$1" >/dev/null 2>&1 &


### PR DESCRIPTION
…rminate if an application to be restarted was not running. This was due to the `set -e` option and the exit code of `pkill`. The fix is to make the `pkill` commands more lenient in the reload scripts.

This commit also includes all the previously implemented improvements to the hypr configuration scripts:
- Dependency checking
- Centralized path management
- A modular theming system
- Improved user feedback