### PR TITLE
Enhance editor configurations for various languages

### DIFF
--- a/doom/init.el
+++ b/doom/init.el
@@ -89,7 +89,7 @@
        ;;grammar           ; tasing grammar mistake every you make
 
        :tools
-       ansible
+       (ansible +lsp)
        ;;biblio            ; Writes a PhD for you (citation needed)
        ;;collab            ; buffers with friends
        ;;debugger          ; FIXME stepping through code, to help you add bugs
@@ -98,7 +98,7 @@
        editorconfig      ; let someone else argue about tabs vs spaces
        ;;ein               ; tame Jupyter notebooks with emacs
        (eval +overlay)     ; run code, run (also, repls)
-       kubernetes
+       (kubernetes +lsp)
        lsp
        lookup              ; navigate your code and its documentation
        magit +forge      ; a git porcelain for Emacs

--- a/nvim/lua/plugins/languages.lua
+++ b/nvim/lua/plugins/languages.lua
@@ -4,7 +4,6 @@ return {
 		dependencies = { "mason-org/mason.nvim" },
 		opts = {
 			ensure_installed = {
-				"black",
 				"shfmt",
 				"markdownlint",
 				"clang-format",
@@ -18,6 +17,7 @@ return {
 				"ruff",
 				"yaml-language-server",
 				"hadolint",
+				"bash-language-server",
 			},
 		},
 	},
@@ -144,6 +144,8 @@ return {
 				"yaml",
 				"dockerfile",
 				"nginx",
+				"terraform",
+				"helm",
 			},
 		},
 	},


### PR DESCRIPTION
Enhanced Neovim and Doom Emacs configurations to support Python, Shell, Terraform, Ansible, Markdown, YAML and Helm Chart programming. Added missing LSP flags in Doom Emacs and missing servers/parsers in Neovim.

---
*PR created automatically by Jules for task [11042651500430328134](https://jules.google.com/task/11042651500430328134) started by @mclellac*